### PR TITLE
Use sd_bus_message_append shorthand for screenshot

### DIFF
--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -8,6 +8,12 @@ struct xdpw_request {
 	sd_bus_slot *slot;
 };
 
+enum {
+	PORTAL_RESPONSE_SUCCESS = 0,
+	PORTAL_RESPONSE_CANCELLED = 1,
+	PORTAL_RESPONSE_ENDED = 2
+};
+
 int init_screenshot(sd_bus *bus);
 
 struct xdpw_request *request_create(sd_bus *bus, const char *object_path);

--- a/screenshot.c
+++ b/screenshot.c
@@ -54,37 +54,6 @@ static int method_screenshot(sd_bus_message *msg, void *data,
 		return -ENOMEM;
 	}
 
-	sd_bus_message *reply = NULL;
-	ret = sd_bus_message_new_method_return(msg, &reply);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_append(reply, "u", 0);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_open_container(reply, 'a', "{sv}");
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_open_container(reply, 'e', "sv");
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_append_basic(reply, 's', "uri");
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_open_container(reply, 'v', "s");
-	if (ret < 0) {
-		return ret;
-	}
-
 	// TODO: choose a better path
 	const char path[] = "/tmp/out.png";
 	if (!exec_screenshooter(path)) {
@@ -95,22 +64,13 @@ static int method_screenshot(sd_bus_message *msg, void *data,
 	char uri[strlen(path) + strlen(uri_prefix) + 1];
 	snprintf(uri, sizeof(uri), "%s%s", uri_prefix, path);
 
-	ret = sd_bus_message_append_basic(reply, 's', uri);
+	sd_bus_message *reply = NULL;
+	ret = sd_bus_message_new_method_return(msg, &reply);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = sd_bus_message_close_container(reply);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_close_container(reply);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = sd_bus_message_close_container(reply);
+	ret = sd_bus_message_append(reply, "ua{sv}", PORTAL_RESPONSE_SUCCESS, 1, "uri", "s", uri);
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
## What

Combine multiple `sd_bus_message_append` calls.

## Why

Reduces repetition and error handling overhead, makes it easier to see at a glance what is being done.

 