### PR TITLE
Add tooling to README mentioning portal-test and python snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Make sure `XDG_CURRENT_DESKTOP=sway` is set.
 xdg-desktop-portal-wlr
 ```
 
+## Tooling
+
+Useful tools include `dbus-monitor` to watch requests being made,
+and `dbus-send` and the similar `busctl call` for manual dbus calls.
+
+You can test the integration with the [portal-test](https://github.com/matthiasclasen/portal-test) flatpak app.
+
+Alternatively you can trigger it with [trigger-screen-shot.py](https://gitlab.gnome.org/snippets/814) and [xdp-screen-cast.py](https://gitlab.gnome.org/snippets/19).
+
 ## License
 
 MIT


### PR DESCRIPTION
I haven't managed to get `portal-test` to work yet, so have also included links to the python snippets.