### PR TITLE
Screencast session support

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -6,7 +6,6 @@ packages:
   - wayland
   - wayland-protocols
   - pipewire
-  - libdrm
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,11 +1,7 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include <stdarg.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
 
 enum LOGLEVEL { QUIET, ERROR, WARN, INFO, DEBUG, TRACE };
 

--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -1,20 +1,13 @@
 #ifndef PIPEWIRE_SCREENCAST_H
 #define PIPEWIRE_SCREENCAST_H
 
-#include <stdio.h>
-#include <pipewire/pipewire.h>
-#include <spa/utils/result.h>
-#include <spa/param/props.h>
-#include <spa/param/format-utils.h>
-#include <spa/param/video/format-utils.h>
-
-#include "wlr_screencast.h"
 #include "screencast_common.h"
-#include "xdpw.h"
 
 #define BUFFERS 1
 #define ALIGN 16
 
-void *pwr_start(struct xdpw_state *state);
+void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast);
+void xdpw_pwr_core_connect(struct xdpw_state *state);
+void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast);
 
 #endif

--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -7,7 +7,7 @@
 #define ALIGN 16
 
 void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast);
-void xdpw_pwr_core_connect(struct xdpw_state *state);
+int xdpw_pwr_core_connect(struct xdpw_state *state);
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast);
 
 #endif

--- a/include/screencast.h
+++ b/include/screencast.h
@@ -1,17 +1,8 @@
 #ifndef SCREENCAST_H
 #define SCREENCAST_H
 
-#include <errno.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/wait.h>
-#include <sys/mman.h>
-
-#include "pipewire_screencast.h"
 #include "screencast_common.h"
-#include "wlr_screencast.h"
-#include "xdpw.h"
+
+void xdpw_screencast_instance_destroy(struct xdpw_screencast_instance *cast);
 
 #endif

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -5,6 +5,10 @@
 #include <spa/param/video/format-utils.h>
 #include <wayland-client-protocol.h>
 
+// this seems to be right based on
+// https://github.com/flatpak/xdg-desktop-portal/blob/309a1fc0cf2fb32cceb91dbc666d20cf0a3202c2/src/screen-cast.c#L955
+#define XDP_CAST_PROTO_VER 2
+
 enum cursor_modes {
   HIDDEN = 1,
   EMBEDDED = 2,

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -1,21 +1,29 @@
 #ifndef SCREENCAST_COMMON_H
 #define SCREENCAST_COMMON_H
 
-#include <string.h>
 #include <pipewire/pipewire.h>
 #include <spa/param/video/format-utils.h>
-#include <libdrm/drm_fourcc.h>
 #include <wayland-client-protocol.h>
-#include "logger.h"
 
-struct damage {
+enum cursor_modes {
+  HIDDEN = 1,
+  EMBEDDED = 2,
+  METADATA = 4,
+};
+
+enum source_types {
+  MONITOR = 1,
+  WINDOW = 2,
+};
+
+struct xdpw_frame_damage {
 	uint32_t x;
 	uint32_t y;
 	uint32_t width;
 	uint32_t height;
 };
 
-struct simple_frame {
+struct xdpw_frame {
 	uint32_t width;
 	uint32_t height;
 	uint32_t size;
@@ -24,53 +32,65 @@ struct simple_frame {
 	uint64_t tv_sec;
 	uint32_t tv_nsec;
 	enum wl_shm_format format;
-	struct damage *damage;
+	struct xdpw_frame_damage damage;
 	struct wl_buffer *buffer;
 	void *data;
 };
 
-struct screencast_context {
+struct xdpw_screencast_context {
+
+	// xdpw
+	struct xdpw_state *state;
+
 	// pipewire
 	struct pw_context *pwr_context;
 	struct pw_core *core;
-	struct spa_source *event;
-	struct pw_stream *stream;
-	struct spa_hook stream_listener;
-	struct spa_video_info_raw pwr_format;
-	uint32_t seq;
-	uint32_t node_id;
-	bool stream_state;
 
 	// wlroots
-	struct wl_display *display;
 	struct wl_list output_list;
 	struct wl_registry *registry;
 	struct zwlr_screencopy_manager_v1 *screencopy_manager;
 	struct zxdg_output_manager_v1* xdg_output_manager;
 	struct wl_shm *shm;
 
-	// main frame callback
-	struct zwlr_screencopy_frame_v1 *frame_callback;
-
-	// target output
-	struct wayland_output *target_output;
-	uint32_t framerate;
-	bool with_cursor;
-
-	// frame
-	struct zwlr_screencopy_frame_v1 *wlr_frame;
-	struct simple_frame simple_frame;
-
 	// cli options
 	const char *output_name;
 	const char *forced_pixelformat;
 
-	// if something happens during capture
+	// sessions
+	struct wl_list screencast_instances;
+};
+
+struct xdpw_screencast_instance {
+	// list
+	struct wl_list link;
+
+	// xdpw
+	uint32_t refcount;
+	struct xdpw_screencast_context *ctx;
+	bool initialized;
+
+	// pipewire
+	struct spa_source *event;
+	struct pw_stream *stream;
+	struct spa_hook stream_listener;
+	struct spa_video_info_raw pwr_format;
+	uint32_t seq;
+	uint32_t node_id;
+	bool pwr_stream_state;
+
+	// wlroots
+	struct zwlr_screencopy_frame_v1 *frame_callback;
+	struct xdpw_wlr_output *target_output;
+	uint32_t framerate;
+	struct zwlr_screencopy_frame_v1 *wlr_frame;
+	struct xdpw_frame simple_frame;
+	bool with_cursor;
 	int err;
 	bool quit;
 };
 
-struct wayland_output {
+struct xdpw_wlr_output {
 	struct wl_list link;
 	uint32_t id;
 	struct wl_output *output;
@@ -83,6 +103,7 @@ struct wayland_output {
 	float framerate;
 };
 
-uint32_t pipewire_from_wl_shm(void *data);
+void randname(char *buf);
+uint32_t xdpw_format_pw_from_wl_shm(void *data);
 
 #endif /* SCREENCAST_COMMON_H */

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -1,37 +1,22 @@
 #ifndef WLR_SCREENCAST_H
 #define WLR_SCREENCAST_H
 
-#include "wlr-screencopy-unstable-v1-client-protocol.h"
-#include "xdg-output-unstable-v1-client-protocol.h"
-#include <fcntl.h>
-#include <limits.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#include <wayland-client-protocol.h>
-
-#include "pipewire_screencast.h"
 #include "screencast_common.h"
 
 #define SC_MANAGER_VERSION 2
 
 struct xdpw_state;
 
-void wlr_frame_free(struct xdpw_state *state);
-int wlr_screencopy_init(struct xdpw_state *state);
-void wlr_screencopy_uninit(struct screencast_context *ctx);
+int xdpw_wlr_screencopy_init(struct xdpw_state *state);
+void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx);
 
-struct wayland_output *wlr_output_find_by_name(struct wl_list *output_list,
+struct xdpw_wlr_output *xdpw_wlr_output_find_by_name(struct wl_list *output_list,
 	const char *name);
-struct wayland_output *wlr_output_find(struct screencast_context *ctx,
+struct xdpw_wlr_output *xdpw_wlr_output_first(struct wl_list *output_list);
+struct xdpw_wlr_output *xdpw_wlr_output_find(struct xdpw_screencast_context *ctx,
 	struct wl_output *out, uint32_t id);
-struct wayland_output *wlr_output_first(struct wl_list *output_list);
 
-void wlr_register_cb(struct xdpw_state *state);
+void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast);
+void xdpw_wlr_register_cb(struct xdpw_screencast_instance *cast);
 
 #endif

--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -7,15 +7,17 @@
 #elif HAVE_ELOGIND
 #include <elogind/sd-bus.h>
 #endif
-#include "logger.h"
-#include "screencast.h"
+
+#include "screencast_common.h"
 
 struct xdpw_state {
+	struct wl_list xdpw_sessions;
 	sd_bus *bus;
 	struct wl_display *wl_display;
 	struct pw_loop *pw_loop;
-
-	struct screencast_context screencast;
+	struct xdpw_screencast_context screencast;
+	enum source_types screencast_source_types;
+	enum cursor_modes screencast_cursor_modes;
 };
 
 struct xdpw_request {
@@ -23,7 +25,10 @@ struct xdpw_request {
 };
 
 struct xdpw_session {
+	struct wl_list link;
 	sd_bus_slot *slot;
+	const char *session_handle;
+	struct xdpw_screencast_instance *screencast_instance;
 };
 
 enum {
@@ -32,14 +37,14 @@ enum {
 	PORTAL_RESPONSE_ENDED = 2
 };
 
-int init_screenshot(struct xdpw_state *state);
-int init_screencast(struct xdpw_state *state, const char *output_name,
+int xdpw_screenshot_init(struct xdpw_state *state);
+int xdpw_screencast_init(struct xdpw_state *state, const char *output_name,
 	const char *forced_pixelformat);
 
-struct xdpw_request *request_create(sd_bus *bus, const char *object_path);
-void request_destroy(struct xdpw_request *req);
+struct xdpw_request *xdpw_request_create(sd_bus *bus, const char *object_path);
+void xdpw_request_destroy(struct xdpw_request *req);
 
-struct xdpw_session *session_create(sd_bus *bus, const char *object_path);
-void session_destroy(struct xdpw_session *req);
+struct xdpw_session *xdpw_session_create(struct xdpw_state *state, sd_bus *bus, const char *object_path);
+void xdpw_session_destroy(struct xdpw_session *req);
 
 #endif

--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -16,8 +16,9 @@ struct xdpw_state {
 	struct wl_display *wl_display;
 	struct pw_loop *pw_loop;
 	struct xdpw_screencast_context screencast;
-	enum source_types screencast_source_types;
-	enum cursor_modes screencast_cursor_modes;
+	uint32_t screencast_source_types; // bitfield of enum source_types
+	uint32_t screencast_cursor_modes; // bitfield of enum cursor_modes
+	uint32_t screencast_version;
 };
 
 struct xdpw_request {
@@ -27,7 +28,7 @@ struct xdpw_request {
 struct xdpw_session {
 	struct wl_list link;
 	sd_bus_slot *slot;
-	const char *session_handle;
+	char *session_handle;
 	struct xdpw_screencast_instance *screencast_instance;
 };
 
@@ -44,7 +45,7 @@ int xdpw_screencast_init(struct xdpw_state *state, const char *output_name,
 struct xdpw_request *xdpw_request_create(sd_bus *bus, const char *object_path);
 void xdpw_request_destroy(struct xdpw_request *req);
 
-struct xdpw_session *xdpw_session_create(struct xdpw_state *state, sd_bus *bus, const char *object_path);
+struct xdpw_session *xdpw_session_create(struct xdpw_state *state, sd_bus *bus, char *object_path);
 void xdpw_session_destroy(struct xdpw_session *req);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,6 @@ rt = cc.find_library('rt')
 pipewire = dependency('libpipewire-0.3', version: '>= 0.2.9')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
-drm = dependency('libdrm').partial_dependency(includes: true)
 
 logind = dependency('libsystemd', required: false)
 if logind.found()
@@ -56,7 +55,6 @@ executable(
 		logind,
 		pipewire,
 		rt,
-		drm
 	],
 	include_directories: [inc],
 	install: true,

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -1,5 +1,10 @@
 #include "logger.h"
 
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 static int NUM_LEVELS = 6;
 
 static const char *loglevels[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -6,7 +6,6 @@
 #include <pipewire/pipewire.h>
 #include <spa/utils/result.h>
 #include "xdpw.h"
-#include "screencast_common.h"
 #include "logger.h"
 
 enum event_loop_fd {
@@ -79,13 +78,14 @@ int main(int argc, char *argv[]) {
 		logprint(ERROR, "dbus: failed to connect to user bus: %s", strerror(-ret));
 		goto error;
 	}
+	logprint(TRACE, "dbus: connected");
 
 	struct wl_display *wl_display = wl_display_connect(NULL);
 	if (!wl_display) {
 		logprint(ERROR, "wayland: failed to connect to display");
 		goto error;
 	}
-	logprint(INFO, "wlroots: wl_display fd: %d", wl_display_get_fd(wl_display));
+	logprint(TRACE, "wlroots: wl_display connected");
 
 	pw_init(NULL, NULL);
 	struct pw_loop *pw_loop = pw_loop_new(NULL);
@@ -93,20 +93,25 @@ int main(int argc, char *argv[]) {
 		logprint(ERROR, "pipewire: failed to create loop");
 		goto error;
 	}
+	logprint(TRACE, "pipewire: pw_loop created");
 
 	struct xdpw_state state = {
-		.xdpw_sessions = (struct wl_list) { 0 },
 		.bus = bus,
 		.wl_display = wl_display,
 		.pw_loop = pw_loop,
 		.screencast_source_types = MONITOR,
 		.screencast_cursor_modes = HIDDEN | EMBEDDED,
+		.screencast_version = XDP_CAST_PROTO_VER,
 	};
 
 	wl_list_init(&state.xdpw_sessions);
 
 	xdpw_screenshot_init(&state);
-	xdpw_screencast_init(&state, output_name, forced_pixelformat);
+	ret = xdpw_screencast_init(&state, output_name, forced_pixelformat);
+	if (ret < 0) {
+		logprint(ERROR, "xdpw: failed to initialize screencast");
+		goto error;
+	}
 
 	ret = sd_bus_request_name(bus, service_name, 0);
 	if (ret < 0) {
@@ -181,5 +186,6 @@ error:
 	sd_bus_unref(bus);
 	pw_loop_leave(state.pw_loop);
 	pw_loop_destroy(state.pw_loop);
+	wl_display_disconnect(state.wl_display);
 	return EXIT_FAILURE;
 }

--- a/src/core/request.c
+++ b/src/core/request.c
@@ -11,8 +11,6 @@ static int method_close(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct xdpw_request *req = data;
 	int ret = 0;
-	// struct xdpw_request *req = data;
-	// TODO
 	logprint(INFO, "dbus: request closed");
 
 	sd_bus_message *reply = NULL;

--- a/src/core/request.c
+++ b/src/core/request.c
@@ -3,13 +3,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include "xdpw.h"
+#include "logger.h"
 
 static const char interface_name[] = "org.freedesktop.impl.portal.Request";
 
 static int method_close(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
-	
-	int ret = 0; 
+	struct xdpw_request *req = data;
+	int ret = 0;
 	// struct xdpw_request *req = data;
 	// TODO
 	logprint(INFO, "dbus: request closed");
@@ -25,7 +26,9 @@ static int method_close(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	sd_bus_message_unref(reply);	
+	sd_bus_message_unref(reply);
+
+	xdpw_request_destroy(req);
 
 	return 0;
 }
@@ -36,7 +39,7 @@ static const sd_bus_vtable request_vtable[] = {
 	SD_BUS_VTABLE_END
 };
 
-struct xdpw_request *request_create(sd_bus *bus, const char *object_path) {
+struct xdpw_request *xdpw_request_create(sd_bus *bus, const char *object_path) {
 	struct xdpw_request *req = calloc(1, sizeof(struct xdpw_request));
 
 	if (sd_bus_add_object_vtable(bus, &req->slot, object_path, interface_name,
@@ -50,7 +53,7 @@ struct xdpw_request *request_create(sd_bus *bus, const char *object_path) {
 	return req;
 }
 
-void request_destroy(struct xdpw_request *req) {
+void xdpw_request_destroy(struct xdpw_request *req) {
 	if (req == NULL) {
 		return;
 	}

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -3,15 +3,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include "xdpw.h"
+#include "screencast.h"
+#include "logger.h"
 
 static const char interface_name[] = "org.freedesktop.impl.portal.Session";
 
 static int method_close(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
-	
 	int ret = 0;
-	// struct xdpw_session *session = data;
-	// TODO
+	struct xdpw_session *sess = data;
 	logprint(INFO, "dbus: session closed");
 
 	sd_bus_message *reply = NULL;
@@ -27,6 +27,8 @@ static int method_close(sd_bus_message *msg, void *data,
 
 	sd_bus_message_unref(reply);
 
+	xdpw_session_destroy(sess);
+
 	return 0;
 }
 
@@ -36,24 +38,38 @@ static const sd_bus_vtable session_vtable[] = {
 	SD_BUS_VTABLE_END
 };
 
-struct xdpw_session *session_create(sd_bus *bus, const char *object_path) {
-	struct xdpw_session *req = calloc(1, sizeof(struct xdpw_session));
+struct xdpw_session *xdpw_session_create(struct xdpw_state *state, sd_bus *bus, const char *object_path) {
+	struct xdpw_session *sess = calloc(1, sizeof(struct xdpw_session));
 
-	if (sd_bus_add_object_vtable(bus, &req->slot, object_path, interface_name,
-			session_vtable, NULL) < 0) {
-		free(req);
+	sess->session_handle = object_path;
+
+	if (sd_bus_add_object_vtable(bus, &sess->slot, object_path, interface_name,
+			session_vtable, sess) < 0) {
+		free(sess);
 		logprint(ERROR, "dbus: sd_bus_add_object_vtable failed: %s",
 			strerror(-errno));
 		return NULL;
 	}
 
-	return req;
+	wl_list_insert(&state->xdpw_sessions, &sess->link);
+	return sess;
 }
 
-void session_destroy(struct xdpw_session *req) {
-	if (req == NULL) {
+void xdpw_session_destroy(struct xdpw_session *sess) {
+	struct xdpw_screencast_instance *cast = sess->screencast_instance;
+	logprint(TRACE, "dbus: destroying session");
+	if (sess == NULL) {
 		return;
 	}
-	sd_bus_slot_unref(req->slot);
-	free(req);
+	if (cast){
+		--cast->refcount;
+		logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);
+		if (cast->refcount < 1) {
+			cast->quit = true;
+		}
+	}
+
+	sd_bus_slot_unref(sess->slot);
+	wl_list_remove(&sess->link);
+	free(sess);
 }

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -1,5 +1,15 @@
 #include "pipewire_screencast.h"
 
+#include <pipewire/pipewire.h>
+#include <spa/utils/result.h>
+#include <spa/param/props.h>
+#include <spa/param/format-utils.h>
+#include <spa/param/video/format-utils.h>
+
+#include "wlr_screencast.h"
+#include "xdpw.h"
+#include "logger.h"
+
 static void writeFrameData(void *pwFramePointer, void *wlrFramePointer,
 		uint32_t height, uint32_t stride, bool inverted) {
 	if (!inverted) {
@@ -17,8 +27,7 @@ static void writeFrameData(void *pwFramePointer, void *wlrFramePointer,
 }
 
 static void pwr_on_event(void *data, uint64_t expirations) {
-	struct xdpw_state *state = data;
-	struct screencast_context *ctx = &state->screencast;
+	struct xdpw_screencast_instance *cast = data;
 	struct pw_buffer *pw_buf;
 	struct spa_buffer *spa_buf;
 	struct spa_meta_header *h;
@@ -27,7 +36,7 @@ static void pwr_on_event(void *data, uint64_t expirations) {
 	logprint(TRACE, "********************");
 	logprint(TRACE, "pipewire: event fired");
 
-	if ((pw_buf = pw_stream_dequeue_buffer(ctx->stream)) == NULL) {
+	if ((pw_buf = pw_stream_dequeue_buffer(cast->stream)) == NULL) {
 		logprint(WARN, "pipewire: out of buffers");
 		return;
 	}
@@ -41,60 +50,58 @@ static void pwr_on_event(void *data, uint64_t expirations) {
 	if ((h = spa_buffer_find_meta_data(spa_buf, SPA_META_Header, sizeof(*h)))) {
 		h->pts = -1;
 		h->flags = 0;
-		h->seq = ctx->seq++;
+		h->seq = cast->seq++;
 		h->dts_offset = 0;
 	}
 
 	d[0].type = SPA_DATA_MemPtr;
-	d[0].maxsize = ctx->simple_frame.size;
+	d[0].maxsize = cast->simple_frame.size;
 	d[0].mapoffset = 0;
-	d[0].chunk->size = ctx->simple_frame.size;
-	d[0].chunk->stride = ctx->simple_frame.stride;
+	d[0].chunk->size = cast->simple_frame.size;
+	d[0].chunk->stride = cast->simple_frame.stride;
 	d[0].chunk->offset = 0;
 	d[0].flags = 0;
 	d[0].fd = -1;
 
-	writeFrameData(d[0].data, ctx->simple_frame.data, ctx->simple_frame.height,
-		ctx->simple_frame.stride, ctx->simple_frame.y_invert);
+	writeFrameData(d[0].data, cast->simple_frame.data, cast->simple_frame.height,
+		cast->simple_frame.stride, cast->simple_frame.y_invert);
 
 	logprint(TRACE, "pipewire: pointer %p", d[0].data);
 	logprint(TRACE, "pipewire: size %d", d[0].maxsize);
 	logprint(TRACE, "pipewire: stride %d", d[0].chunk->stride);
-	logprint(TRACE, "pipewire: width %d", ctx->simple_frame.width);
-	logprint(TRACE, "pipewire: height %d", ctx->simple_frame.height);
-	logprint(TRACE, "pipewire: y_invert %d", ctx->simple_frame.y_invert);
+	logprint(TRACE, "pipewire: width %d", cast->simple_frame.width);
+	logprint(TRACE, "pipewire: height %d", cast->simple_frame.height);
+	logprint(TRACE, "pipewire: y_invert %d", cast->simple_frame.y_invert);
 	logprint(TRACE, "********************");
 
-	pw_stream_queue_buffer(ctx->stream, pw_buf);
+	pw_stream_queue_buffer(cast->stream, pw_buf);
 
-	wlr_frame_free(state);
+	xdpw_wlr_frame_free(cast);
 }
 
 static void pwr_handle_stream_state_changed(void *data,
 		enum pw_stream_state old, enum pw_stream_state state, const char *error) {
-	struct xdpw_state *xdpw_state = data;
-	struct screencast_context *ctx = &xdpw_state->screencast;
-	ctx->node_id = pw_stream_get_node_id(ctx->stream);
+	struct xdpw_screencast_instance *cast = data;
+	cast->node_id = pw_stream_get_node_id(cast->stream);
 
 	logprint(INFO, "pipewire: stream state changed to \"%s\"",
 		pw_stream_state_as_string(state));
-	logprint(INFO, "pipewire: node id is %d", ctx->node_id);
+	logprint(INFO, "pipewire: node id is %d", cast->node_id);
 
 	switch (state) {
 	case PW_STREAM_STATE_STREAMING:
-		ctx->stream_state = true;
+		cast->pwr_stream_state = true;
 		break;
 	default:
-		ctx->stream_state = false;
+		cast->pwr_stream_state = false;
 		break;
 	}
 }
 
 static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		const struct spa_pod *param) {
-	struct xdpw_state *xdpw_state = data;
-	struct screencast_context *ctx = &xdpw_state->screencast;
-	struct pw_stream *stream = ctx->stream;
+	struct xdpw_screencast_instance *cast = data;
+	struct pw_stream *stream = cast->stream;
 	uint8_t params_buffer[1024];
 	struct spa_pod_builder b =
 		SPA_POD_BUILDER_INIT(params_buffer, sizeof(params_buffer));
@@ -104,14 +111,14 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		return;
 	}
 
-	spa_format_video_raw_parse(param, &ctx->pwr_format);
+	spa_format_video_raw_parse(param, &cast->pwr_format);
 
 	params[0] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
 		SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(BUFFERS, 1, 32),
 		SPA_PARAM_BUFFERS_blocks,  SPA_POD_Int(1),
-		SPA_PARAM_BUFFERS_size,    SPA_POD_Int(ctx->simple_frame.size),
-		SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(ctx->simple_frame.stride),
+		SPA_PARAM_BUFFERS_size,    SPA_POD_Int(cast->simple_frame.size),
+		SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(cast->simple_frame.stride),
 		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(ALIGN));
 
 	params[1] = spa_pod_builder_add_object(&b,
@@ -128,66 +135,87 @@ static const struct pw_stream_events pwr_stream_events = {
 	.param_changed = pwr_handle_stream_param_changed,
 };
 
-void *pwr_start(struct xdpw_state *state) {
-	struct screencast_context *ctx = &state->screencast;
+void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast) {
+	struct xdpw_screencast_context *ctx = cast->ctx;
+	struct xdpw_state *state = ctx->state;
+
 	pw_loop_enter(state->pw_loop);
 
 	const struct spa_pod *params[1];
 	uint8_t buffer[1024];
 	struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
 
-	ctx->pwr_context = pw_context_new(state->pw_loop, NULL, 0);
-	if (!ctx->pwr_context) {
-		logprint(ERROR, "pipewire: failed to create context");
-		abort();
-	}
-
-	ctx->core = pw_context_connect(ctx->pwr_context, NULL, 0);
-	if (!ctx->core) {
-		logprint(ERROR, "pipewire: couldn't connect to context");
-		abort();
-	}
-
-	ctx->stream = pw_stream_new(ctx->core, "xdg-desktop-portal-wlr",
+	char name[] = "xdpw-stream-XXXXXX";
+	randname(name + strlen(name) - 6);
+	cast->stream = pw_stream_new(ctx->core, name,
 		pw_properties_new(
 			PW_KEY_MEDIA_CLASS, "Video/Source",
 			NULL));
 
-	if (!ctx->stream) {
+	if (!cast->stream) {
 		logprint(ERROR, "pipewire: failed to create stream");
 		abort();
 	}
-	ctx->stream_state = false;
+	cast->pwr_stream_state = false;
 
 	/* make an event to signal frame ready */
-	ctx->event =
-		pw_loop_add_event(state->pw_loop, pwr_on_event, state);
+	cast->event =
+		pw_loop_add_event(state->pw_loop, pwr_on_event, cast);
+	logprint(TRACE, "pipewire: registered event %p", cast->event);
 
 	params[0] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
 		SPA_FORMAT_mediaType,       SPA_POD_Id(SPA_MEDIA_TYPE_video),
 		SPA_FORMAT_mediaSubtype,    SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
-		SPA_FORMAT_VIDEO_format,    SPA_POD_Id(pipewire_from_wl_shm(ctx)),
+		SPA_FORMAT_VIDEO_format,    SPA_POD_Id(xdpw_format_pw_from_wl_shm(cast)),
 		SPA_FORMAT_VIDEO_size,      SPA_POD_CHOICE_RANGE_Rectangle(
-			&SPA_RECTANGLE(ctx->simple_frame.width, ctx->simple_frame.height),
+			&SPA_RECTANGLE(cast->simple_frame.width, cast->simple_frame.height),
 			&SPA_RECTANGLE(1, 1),
 			&SPA_RECTANGLE(4096, 4096)),
 		// variable framerate
 		SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&SPA_FRACTION(0, 1)),
 		SPA_FORMAT_VIDEO_maxFramerate, SPA_POD_CHOICE_RANGE_Fraction(
-			&SPA_FRACTION(ctx->framerate, 1),
+			&SPA_FRACTION(cast->framerate, 1),
 			&SPA_FRACTION(1, 1),
-			&SPA_FRACTION(ctx->framerate, 1)));
+			&SPA_FRACTION(cast->framerate, 1)));
 
-	 pw_stream_add_listener (ctx->stream, &ctx->stream_listener,
-	 	&pwr_stream_events, state);
+	pw_stream_add_listener(cast->stream, &cast->stream_listener,
+		&pwr_stream_events, cast);
 
-	pw_stream_connect(ctx->stream,
+	pw_stream_connect(cast->stream,
 		PW_DIRECTION_OUTPUT,
 		PW_ID_ANY,
 		(PW_STREAM_FLAG_DRIVER |
 			PW_STREAM_FLAG_MAP_BUFFERS),
 		params, 1);
 
-	return NULL;
+}
+
+void xdpw_pwr_core_connect(struct xdpw_state *state){
+	struct xdpw_screencast_context *ctx = &state->screencast;
+
+	logprint(TRACE, "pipewire: establishing connection to core");
+
+	if(!ctx->pwr_context){
+		ctx->pwr_context = pw_context_new(state->pw_loop, NULL, 0);
+		if (!ctx->pwr_context) {
+			logprint(ERROR, "pipewire: failed to create context");
+			abort();
+		}
+	}
+
+	if (!ctx->core) {
+		ctx->core = pw_context_connect(ctx->pwr_context, NULL, 0);
+		if (!ctx->core) {
+			logprint(ERROR, "pipewire: couldn't connect to context");
+			abort();
+		}
+	}
+}
+
+void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast){
+	logprint(TRACE, "pipewire: destroying stream");
+	pw_stream_flush(cast->stream, false);
+	pw_stream_disconnect(cast->stream);
+	pw_stream_destroy(cast->stream);
 }

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -191,16 +191,16 @@ void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast) {
 
 }
 
-void xdpw_pwr_core_connect(struct xdpw_state *state){
+int xdpw_pwr_core_connect(struct xdpw_state *state) {
 	struct xdpw_screencast_context *ctx = &state->screencast;
 
 	logprint(TRACE, "pipewire: establishing connection to core");
 
-	if(!ctx->pwr_context){
+	if (!ctx->pwr_context) {
 		ctx->pwr_context = pw_context_new(state->pw_loop, NULL, 0);
 		if (!ctx->pwr_context) {
 			logprint(ERROR, "pipewire: failed to create context");
-			abort();
+			return -1;
 		}
 	}
 
@@ -208,14 +208,16 @@ void xdpw_pwr_core_connect(struct xdpw_state *state){
 		ctx->core = pw_context_connect(ctx->pwr_context, NULL, 0);
 		if (!ctx->core) {
 			logprint(ERROR, "pipewire: couldn't connect to context");
-			abort();
+			return -1;
 		}
 	}
+	return 0;
 }
 
-void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast){
+void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast) {
 	logprint(TRACE, "pipewire: destroying stream");
 	pw_stream_flush(cast->stream, false);
 	pw_stream_disconnect(cast->stream);
 	pw_stream_destroy(cast->stream);
+	cast->stream = NULL;
 }

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -1,10 +1,12 @@
 #include "screencast_common.h"
+#include <assert.h>
 
 void randname(char *buf) {
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	long r = ts.tv_nsec;
 	for (int i = 0; i < 6; ++i) {
+		assert(buf[i] == 'X');
 		buf[i] = 'A'+(r&15)+(r&16)*2;
 		r >>= 5;
 	}

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -1,18 +1,28 @@
 #include "screencast_common.h"
 
-enum spa_video_format pipewire_from_wl_shm(void *data) {
-	struct screencast_context *ctx = data;
+void randname(char *buf) {
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	long r = ts.tv_nsec;
+	for (int i = 0; i < 6; ++i) {
+		buf[i] = 'A'+(r&15)+(r&16)*2;
+		r >>= 5;
+	}
+}
 
-	if (ctx->forced_pixelformat) {
-		if (strcmp(ctx->forced_pixelformat, "BGRx") == 0) {
+enum spa_video_format xdpw_format_pw_from_wl_shm(void *data) {
+	struct xdpw_screencast_instance *cast = data;
+
+	if (cast->ctx->forced_pixelformat) {
+		if (strcmp(cast->ctx->forced_pixelformat, "BGRx") == 0) {
 			return SPA_VIDEO_FORMAT_BGRx;
 		}
-		if (strcmp(ctx->forced_pixelformat, "RGBx") == 0) {
+		if (strcmp(cast->ctx->forced_pixelformat, "RGBx") == 0) {
 			return SPA_VIDEO_FORMAT_RGBx;
 		}
 	}
 
-	switch (ctx->simple_frame.format) {
+	switch (cast->simple_frame.format) {
 	case WL_SHM_FORMAT_ARGB8888:
 		return SPA_VIDEO_FORMAT_BGRA;
 	case WL_SHM_FORMAT_XRGB8888:

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -17,16 +17,18 @@
 #include <wayland-client-protocol.h>
 
 #include "screencast.h"
-#include "screencast_common.h"
 #include "pipewire_screencast.h"
 #include "xdpw.h"
 #include "logger.h"
 
 void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	zwlr_screencopy_frame_v1_destroy(cast->wlr_frame);
+	cast->wlr_frame = NULL;
 	munmap(cast->simple_frame.data, cast->simple_frame.size);
+	cast->simple_frame.data = NULL;
 	// TODO: reuse this buffer unless we quit or error out
 	wl_buffer_destroy(cast->simple_frame.buffer);
+	cast->simple_frame.buffer = NULL;
 	logprint(TRACE, "wlroots: frame destroyed");
 
 	if (cast->quit || cast->err) {
@@ -35,7 +37,6 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	}
 
 	xdpw_wlr_register_cb(cast);
-
 }
 
 static int anonymous_shm_open(void) {
@@ -377,7 +378,6 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 	struct xdpw_screencast_instance *cast, *tmp_c;
 	wl_list_for_each_safe(cast, tmp_c, &ctx->screencast_instances, link) {
 		cast->quit = true;
-		//xdpw_screencast_instance_destroy(cast);
 	}
 
 	if (ctx->screencopy_manager) {
@@ -386,10 +386,10 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 	if (ctx->shm) {
 		wl_shm_destroy(ctx->shm);
 	}
-	if (ctx->xdg_output_manager){
+	if (ctx->xdg_output_manager) {
 		zxdg_output_manager_v1_destroy(ctx->xdg_output_manager);
 	}
-	if (ctx->registry){
+	if (ctx->registry) {
 		wl_registry_destroy(ctx->registry);
 	}
 }

--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -49,7 +49,7 @@ static int method_screenshot(sd_bus_message *msg, void *data,
 
 	// TODO: cleanup this
 	struct xdpw_request *req =
-		request_create(sd_bus_message_get_bus(msg), handle);
+		xdpw_request_create(sd_bus_message_get_bus(msg), handle);
 	if (req == NULL) {
 		return -ENOMEM;
 	}
@@ -90,7 +90,7 @@ static const sd_bus_vtable screenshot_vtable[] = {
 	SD_BUS_VTABLE_END
 };
 
-int init_screenshot(struct xdpw_state *state) {
+int xdpw_screenshot_init(struct xdpw_state *state) {
 	// TODO: cleanup
 	sd_bus_slot *slot = NULL;
 	return sd_bus_add_object_vtable(state->bus, &slot, object_path, interface_name,


### PR DESCRIPTION
Fixes #13.

This is designed to take pairs of output id and cursor mode and create a single pipewire stream for each unique combo. Until output selection can be controlled at screencast initialization, this doesn't serve much of a purpose, but it is designed with that capability in mind.

~~At the moment, this gets all the way to a pipewire stream PAUSED state and continues processing wlroots frames like it is supposed to, but the stream is not able to activate. I need to investigate changes made to the pipewire portions of the code to see if I created a regression.~~

Edit: The pipewire issues are fixed.

@emersion, in order to give all of these event driven functions an understanding of which session they belong to, I've started to pass around "cast" session objects instead of the xdpw_state or xdpw_screencast_context, which are both more global in nature, but some functions still need access to data in the context or global state object (pw_loop comes to mind). To accomplish this, each session object has a pointer back to the screencast_context and the context holds a pointer back up to the state. Wanted to point this out in case you see any issue with this approach.