### PR TITLE
Fix musl issue with time.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ add_project_arguments(cc.get_supported_arguments([
 	'-Wno-missing-braces',
 	'-Wno-missing-field-initializers',
 	'-Wno-unused-parameter',
+	'-D_POSIX_C_SOURCE=200809L',
 ]), language: 'c')
 
 inc = include_directories('include')

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
-
 #include "screencast.h"
 
 #include <errno.h>

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
-
 #include "wlr_screencast.h"
 
 #include "wlr-screencopy-unstable-v1-client-protocol.h"


### PR DESCRIPTION
This should fix our issues with musl (#28), but pipewire spa code is still misbehaving.