### PR TITLE
core/main.c: Fix error handling

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
 	ret = sd_bus_open_user(&bus);
 	if (ret < 0) {
 		logprint(ERROR, "dbus: failed to connect to user bus: %s", strerror(-ret));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	logprint(DEBUG, "dbus: connected");
 
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
 	if (!wl_display) {
 		logprint(ERROR, "wayland: failed to connect to display");
 		sd_bus_unref(bus);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	logprint(DEBUG, "wlroots: wl_display connected");
 
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
 		logprint(ERROR, "pipewire: failed to create loop");
 		wl_display_disconnect(wl_display);
 		sd_bus_unref(bus);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	logprint(DEBUG, "pipewire: pw_loop created");
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -70,14 +70,15 @@ int main(int argc, char *argv[]) {
 	ret = sd_bus_open_user(&bus);
 	if (ret < 0) {
 		logprint(ERROR, "dbus: failed to connect to user bus: %s", strerror(-ret));
-		goto error;
+		exit(EXIT_FAILURE);
 	}
 	logprint(DEBUG, "dbus: connected");
 
 	struct wl_display *wl_display = wl_display_connect(NULL);
 	if (!wl_display) {
 		logprint(ERROR, "wayland: failed to connect to display");
-		goto error;
+		sd_bus_unref(bus);
+		exit(EXIT_FAILURE);
 	}
 	logprint(DEBUG, "wlroots: wl_display connected");
 
@@ -85,7 +86,9 @@ int main(int argc, char *argv[]) {
 	struct pw_loop *pw_loop = pw_loop_new(NULL);
 	if (!pw_loop) {
 		logprint(ERROR, "pipewire: failed to create loop");
-		goto error;
+		wl_display_disconnect(wl_display);
+		sd_bus_unref(bus);
+		exit(EXIT_FAILURE);
 	}
 	logprint(DEBUG, "pipewire: pw_loop created");
 


### PR DESCRIPTION
The error handling at the `error:` label tears down the whole state. Thus, the state needs to be fully initialized in order for the tear down to succeed. Currently, if e.g. `sd_bus_open_user()` fails, a `segfault` is triggered by the tear down. This commit adds individual tear down code that only touches
stuff that until that point was successfully initialized.