### PR TITLE
core/main: Minor cleanup

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -16,7 +16,7 @@ enum event_loop_fd {
 
 static const char service_name[] = "org.freedesktop.impl.portal.desktop.wlr";
 
-int xdpw_usage(FILE* stream, int rc) {
+static int xdpw_usage(FILE* stream, int rc) {
 	static const char* usage =
 		"Usage: xdg-desktop-portal-wlr [options]\n"
 		"\n"

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -56,9 +56,9 @@ int main(int argc, char *argv[]) {
 			output_name = optarg;
 			break;
 		case 'h':
-			return xdpw_usage(stdout, 0);
+			return xdpw_usage(stdout, EXIT_SUCCESS);
 		default:
-			return xdpw_usage(stderr, 1);
+			return xdpw_usage(stderr, EXIT_FAILURE);
 		}
 	}
 


### PR DESCRIPTION
- No need to create a linker symbol for `xdpw_usage()`
- Using `EXIT_SUCCESS` and `EXIT_FAILURE` over magic numbers is more readable