### PR TITLE
screencast/wlr_screencast Reuse wl_buffer if possible

### DIFF
--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -105,10 +105,12 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 
 	logprint(TRACE, "wlroots: buffer event handler");
 	cast->wlr_frame = frame;
-	if (cast->simple_frame.buffer == NULL || cast->simple_frame.width != width || cast->simple_frame.height != height || cast->simple_frame.stride != stride || cast->simple_frame.format != format) {
+	if (cast->simple_frame.buffer == NULL || cast->simple_frame.data == NULL || cast->simple_frame.width != width || cast->simple_frame.height != height || cast->simple_frame.stride != stride || cast->simple_frame.format != format) {
 		logprint(TRACE, "wlroots: buffer properties changed");
-		munmap(cast->simple_frame.data, cast->simple_frame.size);
-		cast->simple_frame.data = NULL;
+		if (cast->simple_frame.data != NULL) {
+			munmap(cast->simple_frame.data, cast->simple_frame.size);
+			cast->simple_frame.data = NULL;
+		}
 		cast->simple_frame.width = width;
 		cast->simple_frame.height = height;
 		cast->simple_frame.stride = stride;

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -28,8 +28,9 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 		cast->simple_frame.data = NULL;
 		wl_buffer_destroy(cast->simple_frame.buffer);
 		cast->simple_frame.buffer = NULL;
-		logprint(TRACE, "wlroots: frame destroyed");
+		logprint(TRACE, "xdpw: simple_frame buffer destroyed");
 	}
+	logprint(TRACE, "wlroots: frame destroyed");
 
 	if (cast->quit || cast->err) {
 		// TODO: revisit the exit condition (remove quit?)

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -131,21 +131,16 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 		wlr_frame_buffer_chparam(cast, format, width, height, stride);
 	}
 
-	if (cast->simple_frame.buffer == NULL && cast->simple_frame.data == NULL) {
+	if (cast->simple_frame.buffer == NULL) {
 		logprint(DEBUG, "wlroots: create shm buffer");
 		cast->simple_frame.buffer = create_shm_buffer(cast, format, width, height,
 			stride, &cast->simple_frame.data);
 	} else {
-		logprint(DEBUG,"wlroots: shm buffer or data exists");
+		logprint(DEBUG,"wlroots: shm buffer exists");
 	}
 
 	if (cast->simple_frame.buffer == NULL) {
 		logprint(ERROR, "wlroots: failed to create buffer");
-		abort();
-	}
-
-	if (cast->simple_frame.data == NULL) {
-		logprint(ERROR, "wlroots: failed to map data");
 		abort();
 	}
 

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -112,6 +112,10 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 			munmap(cast->simple_frame.data, cast->simple_frame.size);
 			cast->simple_frame.data = NULL;
 		}
+		if (cast->simple_frame.data != NULL) {
+			wl_buffer_destroy(cast->simple_frame.buffer);
+			cast->simple_frame.buffer = NULL;
+		}
 		cast->simple_frame.width = width;
 		cast->simple_frame.height = height;
 		cast->simple_frame.stride = stride;

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -35,7 +35,6 @@ static void wlr_frame_buffer_destroy(struct xdpw_screencast_instance *cast) {
 void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	zwlr_screencopy_frame_v1_destroy(cast->wlr_frame);
 	cast->wlr_frame = NULL;
-	// TODO: reuse this buffer unless we quit or error out
 	if (cast->quit || cast->err) {
 		wlr_frame_buffer_destroy(cast);
 		logprint(TRACE, "xdpw: simple_frame buffer destroyed");

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -136,7 +136,7 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 		cast->simple_frame.buffer = create_shm_buffer(cast, format, width, height,
 			stride, &cast->simple_frame.data);
 	} else {
-		logprint(DEBUG,"wlroots: shm buffer exists");
+		logprint(TRACE,"wlroots: shm buffer exists");
 	}
 
 	if (cast->simple_frame.buffer == NULL) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -19,7 +19,7 @@
 #include "xdpw.h"
 #include "logger.h"
 
-static void wlr_frame_buffer_clear(struct xdpw_screencast_instance *cast) {
+static void wlr_frame_buffer_destroy(struct xdpw_screencast_instance *cast) {
 	// This check isn't needed
 	if (cast->simple_frame.data != NULL) {
 		munmap(cast->simple_frame.data, cast->simple_frame.size);
@@ -37,7 +37,7 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	cast->wlr_frame = NULL;
 	// TODO: reuse this buffer unless we quit or error out
 	if (cast->quit || cast->err) {
-		wlr_frame_buffer_clear(cast);
+		wlr_frame_buffer_destroy(cast);
 		logprint(TRACE, "xdpw: simple_frame buffer destroyed");
 	}
 	logprint(TRACE, "wlroots: frame destroyed");
@@ -119,7 +119,7 @@ static void wlr_frame_buffer_chparam(struct xdpw_screencast_instance *cast,
 	cast->simple_frame.stride = stride;
 	cast->simple_frame.size = stride * height;
 	cast->simple_frame.format = format;
-	wlr_frame_buffer_clear(cast);
+	wlr_frame_buffer_destroy(cast);
 }
 
 static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -25,9 +25,11 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	munmap(cast->simple_frame.data, cast->simple_frame.size);
 	cast->simple_frame.data = NULL;
 	// TODO: reuse this buffer unless we quit or error out
-	wl_buffer_destroy(cast->simple_frame.buffer);
-	cast->simple_frame.buffer = NULL;
-	logprint(TRACE, "wlroots: frame destroyed");
+	if (cast->quit || cast->err) {
+		wl_buffer_destroy(cast->simple_frame.buffer);
+		cast->simple_frame.buffer = NULL;
+		logprint(TRACE, "wlroots: frame destroyed");
+	}
 
 	if (cast->quit || cast->err) {
 		// TODO: revisit the exit condition (remove quit?)

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -20,10 +20,12 @@
 #include "logger.h"
 
 static void wlr_frame_buffer_clear(struct xdpw_screencast_instance *cast) {
+	// This check isn't needed
 	if (cast->simple_frame.data != NULL) {
 		munmap(cast->simple_frame.data, cast->simple_frame.size);
 		cast->simple_frame.data = NULL;
 	}
+	// This one is
 	if (cast->simple_frame.buffer != NULL) {
 		wl_buffer_destroy(cast->simple_frame.buffer);
 		cast->simple_frame.buffer = NULL;

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -20,12 +20,9 @@
 #include "logger.h"
 
 static void wlr_frame_buffer_destroy(struct xdpw_screencast_instance *cast) {
-	// This check isn't needed
-	if (cast->simple_frame.data != NULL) {
-		munmap(cast->simple_frame.data, cast->simple_frame.size);
-		cast->simple_frame.data = NULL;
-	}
-	// This one is
+	munmap(cast->simple_frame.data, cast->simple_frame.size);
+	cast->simple_frame.data = NULL;
+	// wl_buffer_destroy won't work on NULL
 	if (cast->simple_frame.buffer != NULL) {
 		wl_buffer_destroy(cast->simple_frame.buffer);
 		cast->simple_frame.buffer = NULL;


### PR DESCRIPTION
This draft tries to minimize creation and destruction of the cast->simple_frame.buffer and cast->simple_frame.data.