### PR TITLE
systemd: ensure service is stopped on exit of graphical session

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-wlr.service.in
+++ b/contrib/systemd/xdg-desktop-portal-wlr.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Portal service (wlroots implementation)
+PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
I'm learning more about systemd 🙂 

`PartOf=` will ensure that when graphical session ends, this service will be gracefully shutdown. Otherwise display just disappears, and I think the process will crash.

`After=` is only needed to give systemd a hint about order of starting services, I don't think it's strictly necessary for a DBUS-activated service like this one or mako, I guess people add it mostly for semantic reasons.

`[Install]` is not really needed for a DBUS-activated service, because it will start even if you don't `systemctl enable` it.

However if you want I can add it (like in mako), and the effect will be that if a user explicitly `systemctl enable`s this service, it will be launched not on DBUS, but immediately after graphical session starts.