### PR TITLE
Add pipewire buffers_dataType parameter in pipwire_screencast.c

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ add_project_arguments(cc.get_supported_arguments([
 inc = include_directories('include')
 
 rt = cc.find_library('rt')
-pipewire = dependency('libpipewire-0.3', version: '>= 0.2.9')
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.2')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -119,7 +119,8 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		SPA_PARAM_BUFFERS_blocks,  SPA_POD_Int(1),
 		SPA_PARAM_BUFFERS_size,    SPA_POD_Int(cast->simple_frame.size),
 		SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(cast->simple_frame.stride),
-		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(ALIGN));
+		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(ALIGN),
+		SPA_PARAM_BUFFERS_dataType, SPA_POD_Int((1<<SPA_DATA_MemPtr)));
 
 	params[1] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,


### PR DESCRIPTION
Pipewire has a bitmap (dataType buffer parameter) to compare the available buffer types since 0.3.2.