### PR TITLE
Add graphical display chooser

### DIFF
--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,3 +1,5 @@
 [screencast]
 output_name=
 max_fps=30
+chooser_cmd="slurp -f %o -o"
+chooser_type=simple

--- a/include/config.h
+++ b/include/config.h
@@ -2,12 +2,15 @@
 #define CONFIG_H
 
 #include "logger.h"
+#include "screencast_common.h"
 
 struct config_screencast {
 	char *output_name;
 	double max_fps;
 	char *exec_before;
 	char *exec_after;
+	char *chooser_cmd;
+	enum xdpw_chooser_types chooser_type;
 };
 
 struct xdpw_config {

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -22,6 +22,18 @@ enum source_types {
   WINDOW = 2,
 };
 
+enum xdpw_chooser_types {
+  XDPW_CHOOSER_DEFAULT,
+  XDPW_CHOOSER_NONE,
+  XDPW_CHOOSER_SIMPLE,
+  XDPW_CHOOSER_DMENU,
+};
+
+struct xdpw_output_chooser {
+	enum xdpw_chooser_types type;
+	char *cmd;
+};
+
 struct xdpw_frame_damage {
 	uint32_t x;
 	uint32_t y;
@@ -113,4 +125,6 @@ enum spa_video_format xdpw_format_pw_from_wl_shm(
 	struct xdpw_screencast_instance *cast);
 enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format);
 
+enum xdpw_chooser_types get_chooser_type(const char *chooser_type);
+const char *chooser_type_str(enum xdpw_chooser_types chooser_type);
 #endif /* SCREENCAST_COMMON_H */

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -22,6 +22,7 @@ struct xdpw_wlr_output *xdpw_wlr_output_find_by_name(struct wl_list *output_list
 struct xdpw_wlr_output *xdpw_wlr_output_first(struct wl_list *output_list);
 struct xdpw_wlr_output *xdpw_wlr_output_find(struct xdpw_screencast_context *ctx,
 	struct wl_output *out, uint32_t id);
+struct xdpw_wlr_output *xdpw_wlr_output_chooser(struct xdpw_screencast_context *ctx);
 
 void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast);
 void xdpw_wlr_register_cb(struct xdpw_screencast_instance *cast);

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -28,7 +28,7 @@ enum LOGLEVEL get_loglevel(const char *level) {
 	}
 
 	fprintf(stderr, "Could not understand log level %s\n", level);
-	abort();
+	exit(1);
 }
 
 static const char *print_loglevel(enum LOGLEVEL loglevel) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -74,6 +74,7 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'o':
 			config.screencast_conf.output_name = strdup(optarg);
+			config.screencast_conf.chooser_type = XDPW_CHOOSER_NONE;
 			break;
 		case 'c':
 			configfile = strdup(optarg);

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -52,3 +52,32 @@ enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format) {
 		return SPA_VIDEO_FORMAT_UNKNOWN;
 	}
 }
+
+enum xdpw_chooser_types get_chooser_type(const char *chooser_type) {
+	if (!chooser_type || strcmp(chooser_type, "default") == 0) {
+		return XDPW_CHOOSER_DEFAULT;
+	} else if (strcmp(chooser_type, "none") == 0) {
+		return XDPW_CHOOSER_NONE;
+	} else if (strcmp(chooser_type, "simple") == 0) {
+		return XDPW_CHOOSER_SIMPLE;
+	} else if (strcmp(chooser_type, "dmenu") == 0) {
+		return XDPW_CHOOSER_DMENU;
+	}
+	fprintf(stderr, "Could not understand chooser type %s\n", chooser_type);
+	exit(1);
+}
+
+const char *chooser_type_str(enum xdpw_chooser_types chooser_type) {
+	switch (chooser_type) {
+	case XDPW_CHOOSER_DEFAULT:
+		return "default";
+	case XDPW_CHOOSER_NONE:
+		return "none";
+	case XDPW_CHOOSER_SIMPLE:
+		return "simple";
+	case XDPW_CHOOSER_DMENU:
+		return "dmenu";
+	}
+	fprintf(stderr, "Could not find chooser type %d\n", chooser_type);
+	abort();
+}

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -140,7 +140,7 @@ static void wlr_frame_buffer_done(void *data,
 	struct xdpw_screencast_instance *cast = data;
 
 	logprint(TRACE, "wlroots: buffer_done event handler");
-	
+
 	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->simple_frame.buffer);
 	logprint(TRACE, "wlroots: frame copied");
 
@@ -311,6 +311,204 @@ static void wlr_init_xdg_outputs(struct xdpw_screencast_context *ctx) {
 				output->output);
 		wlr_add_xdg_output_listener(output, xdg_output);
 	}
+}
+
+static pid_t spawn_chooser(char *cmd, int chooser_in[2], int chooser_out[2]) {
+	logprint(TRACE,
+			"exec chooser called: cmd %s, pipe chooser_in (%d,%d), pipe chooser_out (%d,%d)",
+			cmd, chooser_in[0], chooser_in[1], chooser_out[0], chooser_out[1]);
+	pid_t pid = fork();
+
+	if (pid < 0) {
+		perror("fork");
+		return pid;
+	} else if (pid == 0) {
+		close(chooser_in[1]);
+		close(chooser_out[0]);
+
+		dup2(chooser_in[0], STDIN_FILENO);
+		dup2(chooser_out[1], STDOUT_FILENO);
+		close(chooser_in[0]);
+		close(chooser_out[1]);
+
+		execl("/bin/sh", "/bin/sh", "-c", cmd, NULL);
+
+		perror("execl");
+		_exit(127);
+	}
+
+	close(chooser_in[0]);
+	close(chooser_out[1]);
+
+	return pid;
+}
+
+static bool wait_chooser(pid_t pid) {
+	int status;
+	if (waitpid(pid ,&status, 0) != -1 && WIFEXITED(status)) {
+		return WEXITSTATUS(status) != 127;
+	}
+	return false;
+}
+
+static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
+		struct wl_list *output_list, struct xdpw_wlr_output **output) {
+	logprint(DEBUG, "wlroots: output chooser called");
+	struct xdpw_wlr_output *out;
+	size_t name_size = 0;
+	char *name = NULL;
+	*output = NULL;
+
+	int chooser_in[2]; //p -> c
+	int chooser_out[2]; //c -> p
+
+	if (pipe(chooser_in) == -1) {
+		perror("pipe chooser_in");
+		logprint(ERROR, "Failed to open pipe chooser_in");
+		goto error_chooser_in;
+	}
+	if (pipe(chooser_out) == -1) {
+		perror("pipe chooser_out");
+		logprint(ERROR, "Failed to open pipe chooser_out");
+		goto error_chooser_out;
+	}
+
+	pid_t pid = spawn_chooser(chooser->cmd, chooser_in, chooser_out);
+	if (pid < 0) {
+		logprint(ERROR, "Failed to fork chooser");
+		goto error_fork;
+	}
+
+	switch (chooser->type) {
+	case XDPW_CHOOSER_DMENU:;
+		FILE *f = fdopen(chooser_in[1], "w");
+		if (f == NULL) {
+			perror("fdopen pipe chooser_in");
+			logprint(ERROR, "Failed to create stream writing to pipe chooser_in");
+			goto error_fork;
+		}
+		wl_list_for_each(out, output_list, link) {
+			fprintf(f, "%s\n", out->name);
+		}
+		fclose(f);
+		break;
+	default:
+		close(chooser_in[1]);
+	}
+
+	if (!wait_chooser(pid)) {
+		close(chooser_out[0]);
+		goto end;
+	}
+
+	FILE *f = fdopen(chooser_out[0], "r");
+	if (f == NULL) {
+		perror("fdopen pipe chooser_out");
+		logprint(ERROR, "Failed to create stream reading from pipe chooser_out");
+		close(chooser_out[0]);
+		goto end;
+	}
+
+	ssize_t nread = getline(&name, &name_size, f);
+	fclose(f);
+	if (nread < 0) {
+		perror("getline failed");
+		goto end;
+	}
+
+	//Strip newline
+	char *p = strchr(name, '\n');
+	if (p != NULL) {
+		*p = '\0';
+	}
+
+	logprint(TRACE, "wlroots: output chooser %s selects output %s", chooser->cmd, name);
+	wl_list_for_each(out, output_list, link) {
+		if (strcmp(out->name, name) == 0) {
+			*output = out;
+			break;
+		}
+	}
+	free(name);
+
+end:
+	return true;
+
+error_fork:
+	close(chooser_out[0]);
+	close(chooser_out[1]);
+error_chooser_out:
+	close(chooser_in[0]);
+	close(chooser_in[1]);
+error_chooser_in:
+	*output = NULL;
+	return false;
+}
+
+static struct xdpw_wlr_output *wlr_output_chooser_default(struct wl_list *output_list) {
+	logprint(DEBUG, "wlroots: output chooser called");
+	struct xdpw_output_chooser default_chooser[] = {
+		{XDPW_CHOOSER_SIMPLE, "slurp -f %o -o"},
+		{XDPW_CHOOSER_DMENU, "wofi -d -n"},
+		{XDPW_CHOOSER_DMENU, "bemenu"},
+	};
+
+	size_t N = sizeof(default_chooser)/sizeof(default_chooser[0]);
+	struct xdpw_wlr_output *output = NULL;
+	bool ret;
+	for (size_t i = 0; i<N; i++) {
+		ret = wlr_output_chooser(&default_chooser[i], output_list, &output);
+		if (!ret) {
+			logprint(DEBUG, "wlroots: output chooser %s not found. Trying next one.",
+					default_chooser[i].cmd);
+			continue;
+		}
+		if (output != NULL) {
+			logprint(DEBUG, "wlroots: output chooser selects %s", output->name);
+		} else {
+			logprint(DEBUG, "wlroots: output chooser canceled");
+		}
+		return output;
+	}
+	return xdpw_wlr_output_first(output_list);
+}
+
+struct xdpw_wlr_output *xdpw_wlr_output_chooser(struct xdpw_screencast_context *ctx) {
+	switch (ctx->state->config->screencast_conf.chooser_type) {
+	case XDPW_CHOOSER_DEFAULT:
+		return wlr_output_chooser_default(&ctx->output_list);
+	case XDPW_CHOOSER_NONE:
+		if (ctx->state->config->screencast_conf.output_name) {
+			return xdpw_wlr_output_find_by_name(&ctx->output_list, ctx->state->config->screencast_conf.output_name);
+		} else {
+			return xdpw_wlr_output_first(&ctx->output_list);
+		}
+	case XDPW_CHOOSER_DMENU:
+	case XDPW_CHOOSER_SIMPLE:;
+		struct xdpw_wlr_output *output = NULL;
+		if (!ctx->state->config->screencast_conf.chooser_cmd) {
+			logprint(ERROR, "wlroots: no output chooser given");
+			goto end;
+		}
+		struct xdpw_output_chooser chooser = {
+			ctx->state->config->screencast_conf.chooser_type,
+			ctx->state->config->screencast_conf.chooser_cmd
+		};
+		logprint(DEBUG, "wlroots: output chooser %s (%d)", chooser.cmd, chooser.type);
+		bool ret = wlr_output_chooser(&chooser, &ctx->output_list, &output);
+		if (!ret) {
+			logprint(ERROR, "wlroots: output chooser %s failed", chooser.cmd);
+			goto end;
+		}
+		if (output) {
+			logprint(DEBUG, "wlroots: output chooser selects %s", output->name);
+		} else {
+			logprint(DEBUG, "wlroots: output chooser canceled");
+		}
+		return output;
+	}
+end:
+	return NULL;
 }
 
 struct xdpw_wlr_output *xdpw_wlr_output_first(struct wl_list *output_list) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -424,7 +424,8 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 
 	logprint(TRACE, "wlroots: output chooser %s selects output %s", chooser->cmd, name);
 	wl_list_for_each(out, output_list, link) {
-		if (strcmp(out->name, name) == 0) {
+		// TODO: Replugging of outputs can result in a corrupted output_list
+		if (out->name && strcmp(out->name, name) == 0) {
 			*output = out;
 			break;
 		}

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -27,6 +27,8 @@ output_name=HDMI-A-1
 max_fps=30
 exec_before=disable_notifications.sh
 exec_after=enable_notifications.sh
+chooser_type=simple
+chooser_cmd="slurp -f %o -o"
 ```
 
 # SCREENCAST OPTIONS
@@ -36,7 +38,7 @@ These options need to be placed under the **[screencast]** section.
 **output_name** = _name_
 	Select which output will be screencast.
 
-	By default, an arbitrary output is selected. The list of available outputs
+	This option is used with **chooser_type** = none. The list of available outputs
 	can be obtained via **wayland-info**(1) (under the _zxdg_output_manager_v1_
 	section).
 
@@ -51,6 +53,36 @@ These options need to be placed under the **[screencast]** section.
 
 **exec_after** = _command_
 	Execute _command_ after ending all screencasts. The command will be executed within sh.
+
+**chooser_cmd** = _command_
+	Run this command to select an output.
+
+	For more details see **OUTPUT CHOOSER**.
+
+**chooser_type** = _type_
+	Specifies the input send to the chooser.
+
+	The supported types are:
+	- default: xdpw will try to use the first chooser found in the list of hardcoded choosers
+	  (slurp, wofi, bemenu) and will fallback to an arbitrary output if none of those were found.
+	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
+	  an arbitrary output without further interaction.
+	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
+	  see **OUTPUT CHOOSER**.
+
+## OUTPUT CHOOSER
+
+The chooser can be any program or script with the following behaviour:
+- It returns any error code except 127. The error code 127 is internally used to signal
+  that no command could be found and all output from it will be ignored.
+- It returns the name of a valid output on stdout as given by **wayland-info**(1).
+  Everything else will be handled as declined by the user.
+- To signal that the user has declined screencast, the chooser should exit without
+  anything on stdout.
+
+Supported types of choosers via the **chooser_type** option:
+- simple: the chooser is just called without anything further on stdin.
+- dmenu: the chooser receives a newline separated list (dmenu style) of outputs on stdin.
 
 # SEE ALSO
 


### PR DESCRIPTION
This provides the posibility to choose the screencast display via a graphical interface provided either by slurp, wofi or dmenu. If a display is given via, the commandline parameter, it is prioritised, in case all selectors fail, it will fall back to the current default. For slurp to work properly https://github.com/emersion/slurp/pull/64 is required.

Note: while this is not merged and man pages are not ready, the locations for a config file are in order:

    $XDG_CONFIG_HOME/xdg-desktop-portal-wlr/$XDG_CURRENT_DESKTOP
    $XDG_CONFIG_HOME/xdg-desktop-portal-wlr/config
    $HOME/.config/xdg-desktop-portal-wlr/$XDG_CURRENT_DESKTOP
    $HOME/.config/xdg-desktop-portal-wlr/config
    /etc/xdg/xdg-desktop-portal-wlr/$XDG_CURRENT_DESKTOP
    /etc/xdg/xdg-desktop-portal-wlr/config
    /etc/xdg-desktop-portal-wlr/$XDG_CURRENT_DESKTOP
    /etc/xdg-desktop-portal-wlr/config

The system wide config can be in another place, if SYSCONFDIR differs from /etc