### PR TITLE
Improve pipewire buffertype handling

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -122,6 +122,7 @@ struct xdpw_wlr_output {
 };
 
 void randname(char *buf);
+int anonymous_shm_open(void);
 enum spa_video_format xdpw_format_pw_from_wl_shm(enum wl_shm_format format);
 enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format);
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -5,6 +5,8 @@
 #include <spa/param/props.h>
 #include <spa/param/format-utils.h>
 #include <spa/param/video/format-utils.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include "wlr_screencast.h"
 #include "xdpw.h"
@@ -145,7 +147,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		SPA_PARAM_BUFFERS_size,    SPA_POD_Int(cast->simple_frame.size),
 		SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(cast->simple_frame.stride),
 		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(XDPW_PWR_ALIGN),
-		SPA_PARAM_BUFFERS_dataType,SPA_POD_CHOICE_FLAGS_Int(1<<SPA_DATA_MemPtr));
+		SPA_PARAM_BUFFERS_dataType,SPA_POD_CHOICE_FLAGS_Int(1<<SPA_DATA_MemFd));
 
 	params[1] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
@@ -164,28 +166,61 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	d = buffer->buffer->datas;
 
 	// Select buffer type from negotiation result
-	if ((d[0].type & (1u << SPA_DATA_MemPtr)) > 0) {
-		d[0].type = SPA_DATA_MemPtr;
+	if ((d[0].type & (1u << SPA_DATA_MemFd)) > 0) {
+		d[0].type = SPA_DATA_MemFd;
 	} else {
 		logprint(ERROR, "pipewire: unsupported buffer type");
 		cast->err = 1;
 		return;
 	}
 
+	logprint(TRACE, "pipewire: selected buffertype %u", d[0].type);
 	// Prepare buffer for choosen type
-	if (d[0].type == SPA_DATA_MemPtr) {
+	if (d[0].type == SPA_DATA_MemFd) {
 		d[0].maxsize = cast->simple_frame.size;
 		d[0].mapoffset = 0;
 		d[0].chunk->size = cast->simple_frame.size;
 		d[0].chunk->stride = cast->simple_frame.stride;
 		d[0].chunk->offset = 0;
 		d[0].flags = 0;
-		d[0].fd = -1;
+		d[0].fd = anonymous_shm_open();
+
+		if (d[0].fd == -1) {
+			logprint(ERROR, "pipewire: unable to create anonymous filedescriptor");
+			cast->err = 1;
+			return;
+		}
+
+		if (ftruncate(d[0].fd, d[0].maxsize) < 0) {
+			logprint(ERROR, "pipewire: unable to truncate filedescriptor");
+			close(d[0].fd);
+			d[0].fd = -1;
+			cast->err = 1;
+			return;
+		}
+
+		// mmap buffer, so we can use the data_ptr in on_process
+		d[0].data = mmap(NULL, d[0].maxsize, PROT_READ | PROT_WRITE, MAP_SHARED, d[0].fd, d[0].mapoffset);
+		if (d[0].data == MAP_FAILED) {
+			logprint(ERROR, "pipewire: unable to mmap memory");
+			cast->err = 1;
+			return;
+		}
 	}
 }
 
 static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer) {
 	logprint(TRACE, "pipewire: remove buffer event handle");
+
+	struct spa_data *d = buffer->buffer->datas;
+	switch (d[0].type) {
+	case SPA_DATA_MemFd:
+		munmap(d[0].data, d[0].maxsize);
+		close(d[0].fd);
+		break;
+	default:
+		break;
+	}
 }
 
 static const struct pw_stream_events pwr_stream_events = {
@@ -250,7 +285,8 @@ void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 	pw_stream_connect(cast->stream,
 		PW_DIRECTION_OUTPUT,
 		PW_ID_ANY,
-		PW_STREAM_FLAG_DRIVER,
+		(PW_STREAM_FLAG_DRIVER |
+			PW_STREAM_FLAG_ALLOC_BUFFERS),
 		&param, 1);
 }
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -250,8 +250,7 @@ void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 	pw_stream_connect(cast->stream,
 		PW_DIRECTION_OUTPUT,
 		PW_ID_ANY,
-		(PW_STREAM_FLAG_DRIVER |
-			PW_STREAM_FLAG_MAP_BUFFERS),
+		PW_STREAM_FLAG_DRIVER,
 		&param, 1);
 }
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -153,7 +153,8 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		SPA_PARAM_BUFFERS_blocks,  SPA_POD_Int(1),
 		SPA_PARAM_BUFFERS_size,    SPA_POD_Int(cast->simple_frame.size),
 		SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(cast->simple_frame.stride),
-		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(XDPW_PWR_ALIGN));
+		SPA_PARAM_BUFFERS_align,   SPA_POD_Int(XDPW_PWR_ALIGN),
+		SPA_PARAM_BUFFERS_dataType,SPA_POD_CHOICE_FLAGS_Int(1<<SPA_DATA_MemPtr));
 
 	params[1] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -85,15 +85,6 @@ static void pwr_on_event(void *data, uint64_t expirations) {
 		h->dts_offset = 0;
 	}
 
-	d[0].type = SPA_DATA_MemPtr;
-	d[0].maxsize = cast->simple_frame.size;
-	d[0].mapoffset = 0;
-	d[0].chunk->size = cast->simple_frame.size;
-	d[0].chunk->stride = cast->simple_frame.stride;
-	d[0].chunk->offset = 0;
-	d[0].flags = 0;
-	d[0].fd = -1;
-
 	writeFrameData(d[0].data, cast->simple_frame.data, cast->simple_frame.height,
 		cast->simple_frame.stride, cast->simple_frame.y_invert);
 
@@ -178,6 +169,18 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	} else {
 		logprint(ERROR, "pipewire: unsupported buffer type");
 		cast->err = 1;
+		return;
+	}
+
+	// Prepare buffer for choosen type
+	if (d[0].type == SPA_DATA_MemPtr) {
+		d[0].maxsize = cast->simple_frame.size;
+		d[0].mapoffset = 0;
+		d[0].chunk->size = cast->simple_frame.size;
+		d[0].chunk->stride = cast->simple_frame.stride;
+		d[0].chunk->offset = 0;
+		d[0].flags = 0;
+		d[0].fd = -1;
 	}
 }
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -164,10 +164,33 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	pw_stream_update_params(stream, params, 2);
 }
 
+static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
+	struct xdpw_screencast_instance *cast = data;
+	struct spa_data *d;
+
+	logprint(TRACE, "pipewire: add buffer event handle");
+
+	d = buffer->buffer->datas;
+
+	// Select buffer type from negotiation result
+	if ((d[0].type & (1u << SPA_DATA_MemPtr)) > 0) {
+		d[0].type = SPA_DATA_MemPtr;
+	} else {
+		logprint(ERROR, "pipewire: unsupported buffer type");
+		cast->err = 1;
+	}
+}
+
+static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer) {
+	logprint(TRACE, "pipewire: remove buffer event handle");
+}
+
 static const struct pw_stream_events pwr_stream_events = {
 	PW_VERSION_STREAM_EVENTS,
 	.state_changed = pwr_handle_stream_state_changed,
 	.param_changed = pwr_handle_stream_param_changed,
+	.add_buffer = pwr_handle_stream_add_buffer,
+	.remove_buffer = pwr_handle_stream_remove_buffer,
 };
 
 void pwr_update_stream_param(struct xdpw_screencast_instance *cast) {

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -1,5 +1,10 @@
 #include "screencast_common.h"
 #include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 void randname(char *buf) {
 	struct timespec ts;
@@ -10,6 +15,25 @@ void randname(char *buf) {
 		buf[i] = 'A'+(r&15)+(r&16)*2;
 		r >>= 5;
 	}
+}
+
+int anonymous_shm_open(void) {
+	char name[] = "/xdpw-shm-XXXXXX";
+	int retries = 100;
+
+	do {
+		randname(name + strlen(name) - 6);
+
+		--retries;
+		// shm_open guarantees that O_CLOEXEC is set
+		int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+		if (fd >= 0) {
+			shm_unlink(name);
+			return fd;
+		}
+	} while (retries > 0 && errno == EEXIST);
+
+	return -1;
 }
 
 enum spa_video_format xdpw_format_pw_from_wl_shm(enum wl_shm_format format) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -61,25 +61,6 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 	}
 }
 
-static int anonymous_shm_open(void) {
-	char name[] = "/xdpw-shm-XXXXXX";
-	int retries = 100;
-
-	do {
-		randname(name + strlen(name) - 6);
-
-		--retries;
-		// shm_open guarantees that O_CLOEXEC is set
-		int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
-		if (fd >= 0) {
-			shm_unlink(name);
-			return fd;
-		}
-	} while (retries > 0 && errno == EEXIST);
-
-	return -1;
-}
-
 static struct wl_buffer *create_shm_buffer(struct xdpw_screencast_instance *cast,
 		enum wl_shm_format fmt, int width, int height, int stride,
 		void **data_out) {


### PR DESCRIPTION
Updated and rebased and probably rewritten large parts of this MR to work with #141. So there are some old and probably some wrong things in the discussions.

-----------------------------------------------------------------------------------------------------------

I looked into buffertype handling in pipewire and talked to @wtay at #pipewire about it.
This draft is to show the current state (of at least my understanding).

-  SPA_PARAM_BUFFERS_dataType
SPA_PARAM_BUFFERS_dataType should be set by a consumer not by a producer as a bitmap to indicate the supported buffer types.
- {add,remove}_buffer callbacks
those callbacks are called, if pipewire adds or removes a new pw_buffer. 
If no alloc flag is used to connect to pipewire the pw_buffer is read-only and buffer->datas[].type contains the supported buffer type bitmap from the client or SPA_DATA_Invalid if the client has not specified anything.
If PW_STREAM_FLAG_ALLOC_BUFFERS is used it's to producers duty to read the bitmap and set at least it's used buffer type and maybe other buffer parameters like size, stride, etc (not sure about that).
- PW_STREAM_FLAG_MAP_BUFFERS
This flag tells pipewire to mmap in case of dmabuf or memfd the fd to the data pointer. Since we are doing our own fd handling i guess, we don't need that (Will clarify if it does anything in case of SPA_DATA_MemPtr). 