### PR TITLE
Add Wayfire to portal UseIn list, as it is also supported

### DIFF
--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
 Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=sway
+UseIn=sway;Wayfire


### PR DESCRIPTION
Quick and dirty change. I intend to add some basic setup to the readme as well, if nobody else is doing that. Mainly just a hint to use the systemctl or dbus to systemd environment setup in autostart, or else the auto loaded portal won't actually work.