### PR TITLE
Control how many frames are captured per second

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,6 +1,7 @@
 image: freebsd/latest
 packages:
   - basu
+  - libepoll-shim
   - meson
   - pipewire
   - pkgconf

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,2 +1,3 @@
 [screencast]
-output=
+output_name=
+max_fps=30

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,7 @@
 
 struct config_screencast {
 	char *output_name;
+	double max_fps;
 };
 
 struct xdpw_config {

--- a/include/fps_limit.h
+++ b/include/fps_limit.h
@@ -1,0 +1,18 @@
+#ifndef FPS_LIMIT_H
+#define FPS_LIMIT_H
+
+#include <stdint.h>
+#include <time.h>
+
+struct fps_limit_state {
+	struct timespec frame_last_time;
+	
+	struct timespec fps_last_time;
+	uint64_t fps_frame_count;
+};
+
+void fps_limit_measure_start(struct fps_limit_state *state, double max_fps);
+
+uint64_t fps_limit_measure_end(struct fps_limit_state *state, double max_fps);
+
+#endif

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -5,6 +5,8 @@
 #include <spa/param/video/format-utils.h>
 #include <wayland-client-protocol.h>
 
+#include "fps_limit.h"
+
 // this seems to be right based on
 // https://github.com/flatpak/xdg-desktop-portal/blob/309a1fc0cf2fb32cceb91dbc666d20cf0a3202c2/src/screen-cast.c#L955
 #define XDP_CAST_PROTO_VER 2
@@ -54,7 +56,7 @@ struct xdpw_screencast_context {
 	struct wl_list output_list;
 	struct wl_registry *registry;
 	struct zwlr_screencopy_manager_v1 *screencopy_manager;
-	struct zxdg_output_manager_v1* xdg_output_manager;
+	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_shm *shm;
 
 	// sessions
@@ -88,6 +90,9 @@ struct xdpw_screencast_instance {
 	bool with_cursor;
 	int err;
 	bool quit;
+
+	// fps limit
+	struct fps_limit_state fps_limit;
 };
 
 struct xdpw_wlr_output {

--- a/include/timespec_util.h
+++ b/include/timespec_util.h
@@ -1,0 +1,18 @@
+#ifndef TIMESPEC_UTIL_H
+#define TIMESPEC_UTIL_H
+
+#include <time.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define TIMESPEC_NSEC_PER_SEC 1000000000L
+
+void timespec_add(struct timespec *t, int64_t delta_ns);
+
+bool timespec_less(struct timespec *t1, struct timespec *t2);
+
+bool timespec_is_zero(struct timespec *t);
+
+int64_t timespec_diff_ns(struct timespec *t1, struct timespec *t2);
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,12 @@ wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 iniparser = cc.find_library('iniparser', dirs: [join_paths(get_option('prefix'),get_option('libdir'))])
 
+epoll = dependency('', required: false)
+if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
+    not cc.has_function('signalfd', prefix: '#include <sys/signalfd.h>'))
+	epoll = dependency('epoll-shim')
+endif
+
 if get_option('sd-bus-provider') == 'auto'
 	assert(get_option('auto_features').auto(), 'sd-bus-provider must not be set to auto since auto_features != auto')
 	sdbus = dependency('libsystemd',
@@ -63,11 +69,14 @@ executable(
 		'src/core/config.c',
 		'src/core/request.c',
 		'src/core/session.c',
+		'src/core/timer.c',
+		'src/core/timespec_util.c',
 		'src/screenshot/screenshot.c',
 		'src/screencast/screencast.c',
 		'src/screencast/screencast_common.c',
 		'src/screencast/wlr_screencast.c',
 		'src/screencast/pipewire_screencast.c',
+		'src/screencast/fps_limit.c'
 	]),
 	dependencies: [
 		wayland_client,
@@ -76,6 +85,7 @@ executable(
 		pipewire,
 		rt,
 		iniparser,
+		epoll,
 	],
 	include_directories: [inc],
 	install: true,

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -39,6 +39,14 @@ static void getstring_from_conffile(dictionary *d,
 	}
 }
 
+static void getdouble_from_conffile(dictionary *d,
+		const char *key, double *dest, double fallback) {
+	if (*dest != 0) {
+		return;
+	}	
+	*dest = iniparser_getdouble(d, key, fallback);
+}
+
 static bool file_exists(const char *path) {
 	return path && access(path, R_OK) != -1;
 }
@@ -70,6 +78,7 @@ static void config_parse_file(const char *configfile, struct xdpw_config *config
 
 	// screencast
 	getstring_from_conffile(d, "screencast:output_name", &config->screencast_conf.output_name, NULL);
+	getdouble_from_conffile(d, "screencast:max_fps", &config->screencast_conf.max_fps, 0);
 
 	iniparser_freedict(d);
 	logprint(DEBUG, "config: config file parsed");

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -1,0 +1,69 @@
+#include <poll.h>
+#include <wayland-util.h>
+#include <sys/timerfd.h>
+
+#include "xdpw.h"
+#include "logger.h"
+#include "timespec_util.h"
+
+static void update_timer(struct xdpw_state *state) {
+	int timer_fd = state->timer_poll_fd;
+	if (timer_fd < 0) {
+		return;
+	}
+
+	bool updated = false;
+	struct xdpw_timer *timer;
+	wl_list_for_each(timer, &state->timers, link) {
+		if (state->next_timer == NULL ||
+				timespec_less(&timer->at, &state->next_timer->at)) {
+			state->next_timer = timer;
+			updated = true;
+		}
+	}
+
+	if (updated) {
+		struct itimerspec delay = { .it_value = state->next_timer->at };
+		errno = 0;
+		int ret = timerfd_settime(timer_fd, TFD_TIMER_ABSTIME, &delay, NULL);
+		if (ret < 0) {
+			fprintf(stderr, "failed to timerfd_settime(): %s\n",
+				strerror(errno));
+		}
+	}
+}
+
+struct xdpw_timer *xdpw_add_timer(struct xdpw_state *state,
+		uint64_t delay_ns, xdpw_event_loop_timer_func_t func, void *data) {
+	struct xdpw_timer *timer = calloc(1, sizeof(struct xdpw_timer));
+	if (timer == NULL) {
+		logprint(ERROR, "Timer allocation failed");
+		return NULL;
+	}
+	timer->state = state;
+	timer->func = func;
+	timer->user_data = data;
+	wl_list_insert(&state->timers, &timer->link);
+
+	clock_gettime(CLOCK_MONOTONIC, &timer->at);
+	timespec_add(&timer->at, delay_ns);
+
+	update_timer(state);
+	return timer;
+}
+
+void xdpw_destroy_timer(struct xdpw_timer *timer) {
+	if (timer == NULL) {
+		return;
+	}
+	struct xdpw_state *state = timer->state;
+
+	if (state->next_timer == timer) {
+		state->next_timer = NULL;
+	}
+
+	wl_list_remove(&timer->link);
+	free(timer);
+
+	update_timer(state);
+}

--- a/src/core/timespec_util.c
+++ b/src/core/timespec_util.c
@@ -1,0 +1,33 @@
+#include "timespec_util.h"
+#include <time.h>
+
+void timespec_add(struct timespec *t, int64_t delta_ns) {
+	int delta_ns_low = delta_ns % TIMESPEC_NSEC_PER_SEC;
+	int delta_s_high = delta_ns / TIMESPEC_NSEC_PER_SEC;
+
+	t->tv_sec += delta_s_high;
+
+	t->tv_nsec += (long)delta_ns_low;
+	if (t->tv_nsec >= TIMESPEC_NSEC_PER_SEC) {
+		t->tv_nsec -= TIMESPEC_NSEC_PER_SEC;
+		++t->tv_sec;
+	}
+}
+
+bool timespec_less(struct timespec *t1, struct timespec *t2) {
+	if (t1->tv_sec != t2->tv_sec) {
+		return t1->tv_sec < t2->tv_sec;
+	}
+	return t1->tv_nsec < t2->tv_nsec;
+}
+
+bool timespec_is_zero(struct timespec *t) {
+	return t->tv_sec == 0 && t->tv_nsec == 0;
+}
+
+int64_t timespec_diff_ns(struct timespec *t1, struct timespec *t2) {
+	int64_t s = t1->tv_sec - t2->tv_sec;
+	int64_t ns = t1->tv_nsec - t2->tv_nsec;
+
+	return s * TIMESPEC_NSEC_PER_SEC + ns;
+}

--- a/src/screencast/fps_limit.c
+++ b/src/screencast/fps_limit.c
@@ -1,0 +1,70 @@
+#include "fps_limit.h"
+#include "logger.h"
+#include "timespec_util.h"
+#include <stdint.h>
+#include <time.h>
+#include <unistd.h>
+#include <assert.h>
+
+#define FPS_MEASURE_PERIOD_SEC 5.0
+
+void measure_fps(struct fps_limit_state *state, struct timespec *now);
+
+void fps_limit_measure_start(struct fps_limit_state *state, double max_fps) {
+	if (max_fps <= 0.0) {
+		return;
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &state->frame_last_time);
+}
+
+uint64_t fps_limit_measure_end(struct fps_limit_state *state, double max_fps) {
+	if (max_fps <= 0.0) {
+		return 0;
+	}
+
+	// `fps_limit_measure_start` was not called?
+	assert(!timespec_is_zero(&state->frame_last_time));
+
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	int64_t elapsed_ns = timespec_diff_ns(&now, &state->frame_last_time);
+
+	measure_fps(state, &now);
+
+	int64_t target_ns = (1.0 / max_fps) * TIMESPEC_NSEC_PER_SEC;
+	int64_t delay_ns = target_ns - elapsed_ns;
+	if (delay_ns > 0) {
+		logprint(TRACE, "fps_limit: elapsed time since the last measurement: %u, "
+			"target %u, should delay for %u (ns)", elapsed_ns, target_ns, delay_ns);
+		return delay_ns;
+	} else {
+		logprint(TRACE, "fps_limit: elapsed time since the last measurement: %u, "
+			"target %u, target not met (ns)", elapsed_ns, target_ns);
+		return 0;
+	}
+}
+
+void measure_fps(struct fps_limit_state *state, struct timespec *now) {
+	if (timespec_is_zero(&state->fps_last_time)) {
+		state->fps_last_time = *now;
+		return;
+	}
+
+	state->fps_frame_count++;
+
+	int64_t elapsed_ns = timespec_diff_ns(now, &state->fps_last_time);
+
+	double elapsed_sec = (double) elapsed_ns / (double) TIMESPEC_NSEC_PER_SEC;
+	if (elapsed_sec < FPS_MEASURE_PERIOD_SEC) {
+		return;
+	}
+
+	double avg_frames_per_sec = state->fps_frame_count / elapsed_sec;
+
+	logprint(DEBUG, "fps_limit: average FPS in the last %0.2f seconds: %0.2f",
+		elapsed_sec, avg_frames_per_sec);
+
+	state->fps_last_time = *now;
+	state->fps_frame_count = 0;
+}

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -134,7 +134,7 @@ static int method_screencast_create_session(sd_bus_message *msg, void *data,
 	logprint(INFO, "dbus: session_handle: %s", session_handle);
 	logprint(INFO, "dbus: app_id: %s", app_id);
 
-	char* key;
+	char *key;
 	int innerRet = 0;
 	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
 		innerRet = sd_bus_message_read(msg, "s", &key);
@@ -143,7 +143,7 @@ static int method_screencast_create_session(sd_bus_message *msg, void *data,
 		}
 
 		if (strcmp(key, "session_handle_token") == 0) {
-			char* token;
+			char *token;
 			sd_bus_message_read(msg, "v", "s", &token);
 			logprint(INFO, "dbus: option token: %s", token);
 		} else {
@@ -223,7 +223,7 @@ static int method_screencast_select_sources(sd_bus_message *msg, void *data,
 	logprint(INFO, "dbus: session_handle: %s", session_handle);
 	logprint(INFO, "dbus: app_id: %s", app_id);
 
-	char* key;
+	char *key;
 	int innerRet = 0;
 	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
 		innerRet = sd_bus_message_read(msg, "s", &key);
@@ -345,7 +345,7 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 	logprint(INFO, "dbus: app_id: %s", app_id);
 	logprint(INFO, "dbus: parent_window: %s", parent_window);
 
-	char* key;
+	char *key;
 	int innerRet = 0;
 	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
 		innerRet = sd_bus_message_read(msg, "s", &key);


### PR DESCRIPTION
Addresses #66 by introducing an optional command-line argument to limit the number of frames captured per second, as the mouse lag issue becomes less noticeable if the frame rate is smaller. The argument represents the targeted frames-per-second value (e.g. pass `-f 10` for 10 FPS).

The implementation took inspiration from https://github.com/any1/wayvnc, but no code was copied other than the file `include/time-util.h`.

The actual FPS value can be lower than the targeted one because xdg-desktop-portal-wlr uses the `zwlr_screencopy_frame_v1_copy_with_damage` function (emphasis on `with_damage`), which waits until the screen changes.

The implementation differs from that of wayvnc that it does not try to "smooth" the capture rate over time, and it always uses the capture time of the last frame as its best estimate for how much time to sleep for current frame, and in order to reach the targeted FPS value. Let me know if there is interest in implementing this - for one, I am not sure if its worth it, and especially on possible implications with regards to xdp only capturing the frame on damage, which can make the measured "time to capture" value vary significantly, and could impact the smoothing negatively (which expects the values to be predictable).

Another difference when compared to wayvnc's implementation is that this code simply suspends the current thread with `usleep`, while wayvnc uses a more sophisticated timer-based solution based on the author's own library https://github.com/any1/aml.

With regards to testing, it seems to (approximately) produce the given targeted FPS value for me, at least as long as I keep changing the screen contents (by moving the mouse, for example). For example, when running with `xdg-desktop-portal-wlr -l DEBUG -f 10`, it produced these logs for me:
```
2020/12/25 18:55:24 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 10.04
2020/12/25 18:55:29 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 9.97
2020/12/25 18:55:34 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 10.07
2020/12/25 18:55:39 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 9.96
2020/12/25 18:55:45 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 10.02
```

Another example with `-f 20`:
```
2020/12/25 19:01:30 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 19.57
2020/12/25 19:01:35 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 19.94
2020/12/25 19:01:40 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 19.93
2020/12/25 19:01:45 [DEBUG] - fps_limit: average FPS in the last 5 seconds: 19.92
```