### PR TITLE
Fix freeze on skipped frame

### DIFF
--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -197,7 +197,6 @@ void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast) {
 		(PW_STREAM_FLAG_DRIVER |
 			PW_STREAM_FLAG_MAP_BUFFERS),
 		&param, 1);
-
 }
 
 int xdpw_pwr_core_connect(struct xdpw_state *state) {

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -38,14 +38,14 @@ static void pwr_on_event(void *data, uint64_t expirations) {
 
 	if ((pw_buf = pw_stream_dequeue_buffer(cast->stream)) == NULL) {
 		logprint(WARN, "pipewire: out of buffers");
-		return;
+		goto out;
 	}
 
 	spa_buf = pw_buf->buffer;
 	d = spa_buf->datas;
 	if ((d[0].data) == NULL) {
 		logprint(TRACE, "pipewire: data pointer undefined");
-		return;
+		goto out;
 	}
 	if ((h = spa_buffer_find_meta_data(spa_buf, SPA_META_Header, sizeof(*h)))) {
 		h->pts = -1;
@@ -76,6 +76,7 @@ static void pwr_on_event(void *data, uint64_t expirations) {
 
 	pw_stream_queue_buffer(cast->stream, pw_buf);
 
+out:
 	xdpw_wlr_frame_free(cast);
 }
 

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -113,7 +113,6 @@ static struct wl_buffer *create_shm_buffer(struct xdpw_screencast_instance *cast
 
 static void wlr_frame_buffer_chparam(struct xdpw_screencast_instance *cast,
 		uint32_t format, uint32_t width, uint32_t height, uint32_t stride) {
-
 	logprint(DEBUG, "wlroots: reset buffer");
 	cast->simple_frame.width = width;
 	cast->simple_frame.height = height;
@@ -126,7 +125,6 @@ static void wlr_frame_buffer_chparam(struct xdpw_screencast_instance *cast,
 static void wlr_frame_linux_dmabuf(void *data,
 		struct zwlr_screencopy_frame_v1 *frame,
 		uint32_t format, uint32_t width, uint32_t height) {
-
 	logprint(TRACE, "wlroots: linux_dmabuf event handler");
 }
 
@@ -190,7 +188,7 @@ static void wlr_frame_ready(void *data, struct zwlr_screencopy_frame_v1 *frame,
 
 	if (!cast->quit && !cast->err && cast->pwr_stream_state) {
 		pw_loop_signal_event(cast->ctx->state->pw_loop, cast->event);
-		return ;
+		return;
 	}
 
 	xdpw_wlr_frame_free(cast);
@@ -229,7 +227,6 @@ static const struct zwlr_screencopy_frame_v1_listener wlr_frame_listener = {
 };
 
 void xdpw_wlr_register_cb(struct xdpw_screencast_instance *cast) {
-
 	cast->frame_callback = zwlr_screencopy_manager_v1_capture_output(
 		cast->ctx->screencopy_manager, cast->with_cursor, cast->target_output->output);
 


### PR DESCRIPTION
When a frame is skipped, we weren't destroying the wlr frame. Since
this function kicks off the next frame capture, the stream was getting
stuck.

Disclaimer: I can't reproduce, please test.

Closes: https://github.com/emersion/xdg-desktop-portal-wlr/issues/81