### PR TITLE
Fix segfault in config_parse_file

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -59,7 +59,7 @@ static char *config_path(char *prefix, char *filename) {
 static void config_parse_file(const char *configfile, struct xdpw_config *config) {
 	dictionary *d = NULL;
 	if (configfile) {
-		logprint(INFO, "config: using config file %s", *configfile);
+		logprint(INFO, "config: using config file %s", configfile);
 		d = iniparser_load(configfile);
 	} else {
 		logprint(INFO, "config: no config file found");


### PR DESCRIPTION
configfile is a `char *`. %s needs a `char *`, so we shouldn't
dereference the pointer here.

Closes: https://github.com/emersion/xdg-desktop-portal-wlr/issues/91