### PR TITLE
Fix link to trigger-screen-shot.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Alternatively you can trigger it with [trigger-screen-shot.py] and
 
 [contributing]: https://github.com/swaywm/wlroots/blob/master/CONTRIBUTING.md
 [portal-test]: https://github.com/matthiasclasen/portal-test
-[trigger-screen-shot.py]: https://gitlab.gnome.org/snippets/814
+[trigger-screen-shot.py]: https://gist.github.com/danshick/3446dac24c64ce6172eced4ac255ac3d
 [xdp-screen-cast.py]: https://gitlab.gnome.org/snippets/19
 
 ## Alternate *.portal Location


### PR DESCRIPTION
The original snippet was deleted from the GNOME GitLab instance. I had an old copy lying around and reuploaded it as a gist for safe keeping. Link is updated to point at this gist.