### PR TITLE
Simplify config paths

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -91,16 +91,20 @@ static char *get_config_path(void) {
 	char *config_home_fallback = calloc(size_fallback, sizeof(char));
 	snprintf(config_home_fallback, size_fallback, "%s/.config", home);
 
-	const char *prefix[3];
-	prefix[0] = getenv("XDG_CONFIG_HOME");
-	prefix[1] = config_home_fallback;
-	prefix[2] = SYSCONFDIR "/xdg";
+	const char *config_home = getenv("XDG_CONFIG_HOME");
+	if (config_home == NULL || config_home[0] == '\0') {
+		config_home = config_home_fallback;
+	}
+
+	const char *prefix[2];
+	prefix[0] = config_home;
+	prefix[1] = SYSCONFDIR "/xdg";
 
 	const char *config[2];
 	config[0] = getenv("XDG_CURRENT_DESKTOP");
 	config[1] = "config";
 
-	for (size_t i = 0; i < 3; i++) {
+	for (size_t i = 0; i < 2; i++) {
 		for (size_t j = 0; j < 2; j++) {
 			char *path = config_path(prefix[i], config[j]);
 			if (!path) {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -43,7 +43,7 @@ static void getdouble_from_conffile(dictionary *d,
 		const char *key, double *dest, double fallback) {
 	if (*dest != 0) {
 		return;
-	}	
+	}
 	*dest = iniparser_getdouble(d, key, fallback);
 }
 
@@ -91,17 +91,16 @@ static char *get_config_path(void) {
 	char *config_home_fallback = calloc(size_fallback, sizeof(char));
 	snprintf(config_home_fallback, size_fallback, "%s/.config", home);
 
-	char *prefix[4];
+	char *prefix[3];
 	prefix[0] = getenv("XDG_CONFIG_HOME");
 	prefix[1] = config_home_fallback;
 	prefix[2] = SYSCONFDIR "/xdg";
-	prefix[3] = SYSCONFDIR;
 
 	char *config[2];
 	config[0] = getenv("XDG_CURRENT_DESKTOP");
 	config[1] = "config";
 
-	for (size_t i = 0; i < 4; i++) {
+	for (size_t i = 0; i < 3; i++) {
 		for (size_t j = 0; j < 2; j++) {
 			char *path = config_path(prefix[i], config[j]);
 			if (!path) {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -51,7 +51,7 @@ static bool file_exists(const char *path) {
 	return path && access(path, R_OK) != -1;
 }
 
-static char *config_path(char *prefix, char *filename) {
+static char *config_path(const char *prefix, const char *filename) {
 	if (!prefix || !prefix[0] || !filename || !filename[0]) {
 		return NULL;
 	}
@@ -91,12 +91,12 @@ static char *get_config_path(void) {
 	char *config_home_fallback = calloc(size_fallback, sizeof(char));
 	snprintf(config_home_fallback, size_fallback, "%s/.config", home);
 
-	char *prefix[3];
+	const char *prefix[3];
 	prefix[0] = getenv("XDG_CONFIG_HOME");
 	prefix[1] = config_home_fallback;
 	prefix[2] = SYSCONFDIR "/xdg";
 
-	char *config[2];
+	const char *config[2];
 	config[0] = getenv("XDG_CURRENT_DESKTOP");
 	config[1] = "config";
 


### PR DESCRIPTION
Drop some config paths from our lookups. See each commit for an explanation.

cc @columbarius 