### PR TITLE
Add exec_before and exec_after

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,8 @@
 struct config_screencast {
 	char *output_name;
 	double max_fps;
+	char *exec_before;
+	char *exec_after;
 };
 
 struct xdpw_config {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -20,6 +20,8 @@ void finish_config(struct xdpw_config *config) {
 
 	// screencast
 	free(&config->screencast_conf.output_name);
+	free(&config->screencast_conf.exec_before);
+	free(&config->screencast_conf.exec_after);
 }
 
 static void getstring_from_conffile(dictionary *d,
@@ -79,6 +81,8 @@ static void config_parse_file(const char *configfile, struct xdpw_config *config
 	// screencast
 	getstring_from_conffile(d, "screencast:output_name", &config->screencast_conf.output_name, NULL);
 	getdouble_from_conffile(d, "screencast:max_fps", &config->screencast_conf.max_fps, 0);
+	getstring_from_conffile(d, "screencast:exec_before", &config->screencast_conf.exec_before, NULL);
+	getstring_from_conffile(d, "screencast:exec_after", &config->screencast_conf.exec_after, NULL);
 
 	iniparser_freedict(d);
 	logprint(DEBUG, "config: config file parsed");

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -25,6 +25,8 @@ The configuration files use the INI file format. Example:
 [screencast]
 output_name=HDMI-A-1
 max_fps=30
+exec_before=disable_notifications.sh
+exec_after=enable_notifications.sh
 ```
 
 # SCREENCAST OPTIONS
@@ -43,6 +45,12 @@ These options need to be placed under the **[screencast]** section.
 
 	This is useful to reduce CPU usage when capturing frames at the output's
 	refresh rate is unnecessary.
+
+**exec_before** = _command_
+	Execute _command_ before starting a screencast. The command will be executed within sh.
+
+**exec_after** = _command_
+	Execute _command_ after ending all screencasts. The command will be executed within sh.
 
 # SEE ALSO
 


### PR DESCRIPTION
I personally find this very useful to disable notifications during a screencast so I thought I'd just put it out there.

It's the first time I touch this codebase so I'm not sure whether I put everything in the right place.