### PR TITLE
Json chooser

### DIFF
--- a/contrib/dmenu-chooser-json.sh
+++ b/contrib/dmenu-chooser-json.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+chooser=$1
+jq  '.monitor | .[] | .name + ": " + .make + " " + .model' | tr -d '"' | ${chooser:="wofi -d"} | cut -d : -f 1

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -27,6 +27,7 @@ enum xdpw_chooser_types {
   XDPW_CHOOSER_NONE,
   XDPW_CHOOSER_SIMPLE,
   XDPW_CHOOSER_DMENU,
+  XDPW_CHOOSER_JSON,
 };
 
 struct xdpw_output_chooser {

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -62,6 +62,8 @@ enum xdpw_chooser_types get_chooser_type(const char *chooser_type) {
 		return XDPW_CHOOSER_SIMPLE;
 	} else if (strcmp(chooser_type, "dmenu") == 0) {
 		return XDPW_CHOOSER_DMENU;
+	} else if (strcmp(chooser_type, "json") == 0) {
+		return XDPW_CHOOSER_JSON;
 	}
 	fprintf(stderr, "Could not understand chooser type %s\n", chooser_type);
 	exit(1);
@@ -77,6 +79,8 @@ const char *chooser_type_str(enum xdpw_chooser_types chooser_type) {
 		return "simple";
 	case XDPW_CHOOSER_DMENU:
 		return "dmenu";
+	case XDPW_CHOOSER_JSON:
+		return "json";
 	}
 	fprintf(stderr, "Could not find chooser type %d\n", chooser_type);
 	abort();

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -379,9 +379,10 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 		goto error_fork;
 	}
 
+	FILE *f;
 	switch (chooser->type) {
 	case XDPW_CHOOSER_DMENU:;
-		FILE *f = fdopen(chooser_in[1], "w");
+		f = fdopen(chooser_in[1], "w");
 		if (f == NULL) {
 			perror("fdopen pipe chooser_in");
 			logprint(ERROR, "Failed to create stream writing to pipe chooser_in");
@@ -390,6 +391,34 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 		wl_list_for_each(out, output_list, link) {
 			fprintf(f, "%s\n", out->name);
 		}
+		fclose(f);
+		break;
+	case XDPW_CHOOSER_JSON:;
+		f = fdopen(chooser_in[1], "w");
+		if (f == NULL) {
+			perror("fdopen pipe chooser_in");
+			logprint(ERROR, "Failed to create stream writing to pipe chooser_in");
+			goto error_fork;
+		}
+		fprintf(f,"{");
+		fprintf(f, "\"monitor\":");
+		fprintf(f,"[");
+		bool first = true;
+		wl_list_for_each(out, output_list, link) {
+			if (first) {
+				fprintf(f,"{");
+				first = false;
+			} else {
+				fprintf(f,",{");
+			}
+			fprintf(f, "\"name\": \"%s\",", out->name);
+			fprintf(f, "\"make\": \"%s\",", out->make);
+			fprintf(f, "\"model\": \"%s\",", out->model);
+			fprintf(f, "\"id\": \"%u\"", out->id);
+			fprintf(f,"}");
+		}
+		fprintf(f,"]");
+		fprintf(f,"}");
 		fclose(f);
 		break;
 	default:
@@ -401,7 +430,7 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 		goto end;
 	}
 
-	FILE *f = fdopen(chooser_out[0], "r");
+	f = fdopen(chooser_out[0], "r");
 	if (f == NULL) {
 		perror("fdopen pipe chooser_out");
 		logprint(ERROR, "Failed to create stream reading from pipe chooser_out");
@@ -485,7 +514,8 @@ struct xdpw_wlr_output *xdpw_wlr_output_chooser(struct xdpw_screencast_context *
 			return xdpw_wlr_output_first(&ctx->output_list);
 		}
 	case XDPW_CHOOSER_DMENU:
-	case XDPW_CHOOSER_SIMPLE:;
+	case XDPW_CHOOSER_SIMPLE:
+	case XDPW_CHOOSER_JSON:;
 		struct xdpw_wlr_output *output = NULL;
 		if (!ctx->state->config->screencast_conf.chooser_cmd) {
 			logprint(ERROR, "wlroots: no output chooser given");

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -67,7 +67,7 @@ These options need to be placed under the **[screencast]** section.
 	  (slurp, wofi, bemenu) and will fallback to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
-	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
+	- simple, dmenu, json: xdpw will launch the chooser given by **chooser_cmd**. For more details
 	  see **OUTPUT CHOOSER**.
 
 ## OUTPUT CHOOSER
@@ -83,6 +83,8 @@ The chooser can be any program or script with the following behaviour:
 Supported types of choosers via the **chooser_type** option:
 - simple: the chooser is just called without anything further on stdin.
 - dmenu: the chooser receives a newline separated list (dmenu style) of outputs on stdin.
+- json: the chooser receives a list of outputs formated as a json stdin ++
+  {"monitor":[{"name": "eDP-1","make": "<manufacturer>","model": "<model>","id": "42"}]}
 
 # SEE ALSO
 


### PR DESCRIPTION
Adds the chooser_type json, which calls the chooser with the output_list formated as json with a script parsing this object and calling a dmenu chooser.

Depends: #59 