### PR TITLE
Fix gcc warnings on invalid `free` call

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -22,10 +22,10 @@ void finish_config(struct xdpw_config *config) {
 	logprint(DEBUG, "config: destroying config");
 
 	// screencast
-	free(&config->screencast_conf.output_name);
-	free(&config->screencast_conf.exec_before);
-	free(&config->screencast_conf.exec_after);
-	free(&config->screencast_conf.chooser_cmd);
+	free(config->screencast_conf.output_name);
+	free(config->screencast_conf.exec_before);
+	free(config->screencast_conf.exec_after);
+	free(config->screencast_conf.chooser_cmd);
 }
 
 static void getstring_from_conffile(dictionary *d,


### PR DESCRIPTION
```
../src/core/config.c: In function ‘finish_config’:
../src/core/config.c:26:9: error: ‘free’ called on pointer ‘config_7(D)’ with nonzero offset 16 [-Werror=free-nonheap-object]
   26 |         free(&config->screencast_conf.exec_before);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/core/config.c:27:9: error: ‘free’ called on pointer ‘config_7(D)’ with nonzero offset 24 [-Werror=free-nonheap-object]
   27 |         free(&config->screencast_conf.exec_after);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/core/config.c:28:9: error: ‘free’ called on pointer ‘config_7(D)’ with nonzero offset 32 [-Werror=free-nonheap-object]
   28 |         free(&config->screencast_conf.chooser_cmd);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```