### PR TITLE
wlr_screencast: remove wl_display_dispatch

### DIFF
--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -630,14 +630,12 @@ int xdpw_wlr_screencopy_init(struct xdpw_state *state) {
 	ctx->registry = wl_display_get_registry(state->wl_display);
 	wl_registry_add_listener(ctx->registry, &wlr_registry_listener, ctx);
 
-	wl_display_dispatch(state->wl_display);
 	wl_display_roundtrip(state->wl_display);
 
 	logprint(DEBUG, "wayland: registry listeners run");
 
 	wlr_init_xdg_outputs(ctx);
 
-	wl_display_dispatch(state->wl_display);
 	wl_display_roundtrip(state->wl_display);
 
 	logprint(DEBUG, "wayland: xdg output listeners run");


### PR DESCRIPTION
wl_display_dispatch is unnecessary and can cause hangs, if no new requests are queued