### PR TITLE
wlr_screencast: fix return value on cmd failure

### DIFF
--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -406,7 +406,7 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 
 	if (!wait_chooser(pid)) {
 		close(chooser_out[0]);
-		goto end;
+		return false;
 	}
 
 	FILE *f = fdopen(chooser_out[0], "r");


### PR DESCRIPTION
Running `xdpw` with no configs (`default` chooser_type) didn't work for me (white window in gum_test on firefox). I didn't have `slurp` nor `wofi` installed, but I had `bemenu`.
Before this patch:
```
2021-04-18 19:39:13.817617637 2021/04/18 19:39:13 [INFO] - wlroots: capturable output: Unknown model: 0x05DF: id: 39 name: eDP-1
2021-04-18 19:39:13.817628300 2021/04/18 19:39:13 [INFO] - wlroots: capturable output: Samsung Electric Company model: S22F350: id: 40 name: HDMI-A-2
2021-04-18 19:39:13.817637339 2021/04/18 19:39:13 [DEBUG] - wlroots: output chooser called
2021-04-18 19:39:13.817647155 2021/04/18 19:39:13 [DEBUG] - wlroots: output chooser called
2021-04-18 19:39:13.817687751 2021/04/18 19:39:13 [TRACE] - exec chooser called: cmd slurp -f %o -o, pipe chooser_in (14,15), pipe chooser_out (16,17)
2021-04-18 19:39:13.818905203 /bin/sh: 1: slurp: not found
2021-04-18 19:39:13.819071740 2021/04/18 19:39:13 [DEBUG] - wlroots: output chooser canceled
2021-04-18 19:39:13.819084601 2021/04/18 19:39:13 [ERROR] - wlroots: no output found
2021-04-18 19:39:13.819607169 2021/04/18 19:39:13 [TRACE] - event-loop: got dbus event
2021-04-18 19:39:13.819653980 2021/04/18 19:39:13 [INFO] - dbus: session closed
2021-04-18 19:39:13.819683358 2021/04/18 19:39:13 [DEBUG] - dbus: destroying session 0x5650605eff00
```
After this patch:
```
2021-04-18 19:45:35.491628675 2021/04/18 19:45:35 [INFO] - wlroots: capturable output: Unknown model: 0x05DF: id: 39 name: eDP-1
2021-04-18 19:45:35.491630858 2021/04/18 19:45:35 [INFO] - wlroots: capturable output: Samsung Electric Company model: S22F350: id: 40 name: HDMI-A-2
2021-04-18 19:45:35.491632470 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser called
2021-04-18 19:45:35.491633997 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser called
2021-04-18 19:45:35.491636411 2021/04/18 19:45:35 [TRACE] - exec chooser called: cmd slurp -f %o -o, pipe chooser_in (14,15), pipe chooser_out (16,17)
2021-04-18 19:45:35.492397594 /bin/sh: 1: slurp: not found
2021-04-18 19:45:35.492578946 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser slurp -f %o -o not found. Trying next one.
2021-04-18 19:45:35.492592519 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser called
2021-04-18 19:45:35.492615093 2021/04/18 19:45:35 [TRACE] - exec chooser called: cmd wofi -d -n, pipe chooser_in (14,15), pipe chooser_out (16,17)
2021-04-18 19:45:35.493726454 /bin/sh: 1: wofi: not found
2021-04-18 19:45:35.494329159 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser wofi -d -n not found. Trying next one.
2021-04-18 19:45:35.494334103 2021/04/18 19:45:35 [DEBUG] - wlroots: output chooser called
2021-04-18 19:45:35.494336573 2021/04/18 19:45:35 [TRACE] - exec chooser called: cmd bemenu, pipe chooser_in (14,15), pipe chooser_out (16,17)
2021-04-18 19:45:44.141900062 2021/04/18 19:45:44 [TRACE] - wlroots: output chooser bemenu selects output HDMI-A-2
2021-04-18 19:45:44.141969518 2021/04/18 19:45:44 [DEBUG] - wlroots: output chooser selects HDMI-A-2
2021-04-18 19:45:44.141972164 2021/04/18 19:45:44 [INFO] - xdpw: screencast instance 0x55789187fba0 has 1 references
2021-04-18 19:45:44.141974822 2021/04/18 19:45:44 [INFO] - xdpw: 1 active screencast instances
2021-04-18 19:45:44.141991128 2021/04/18 19:45:44 [INFO] - wlroots: output: HDMI-A-2
2021-04-18 19:45:44.147655247 2021/04/18 19:45:44 [TRACE] - event-loop: got dbus event
2021-04-18 19:45:44.148603893 2021/04/18 19:45:44 [TRACE] - event-loop: got dbus event
2021-04-18 19:45:44.148610661 2021/04/18 19:45:44 [INFO] - dbus: start method invoked
2021-04-18 19:45:44.148614199 2021/04/18 19:45:44 [INFO] - dbus: request_handle: /org/freedesktop/portal/desktop/request/1_4/webrtc1053890640
2021-04-18 19:45:44.148617555 2021/04/18 19:45:44 [INFO] - dbus: session_handle: /org/freedesktop/portal/desktop/session/1_4/webrtc_session216957630
```
Can you reproduce this?