### PR TITLE
Revert "screencast: workaround corrupted output_list"

### DIFF
--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -432,8 +432,7 @@ static bool wlr_output_chooser(struct xdpw_output_chooser *chooser,
 
 	logprint(TRACE, "wlroots: output chooser %s selects output %s", chooser->cmd, name);
 	wl_list_for_each(out, output_list, link) {
-		// TODO: Replugging of outputs can result in a corrupted output_list
-		if (out->name && strcmp(out->name, name) == 0) {
+		if (strcmp(out->name, name) == 0) {
 			*output = out;
 			break;
 		}

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -634,6 +634,13 @@ int xdpw_wlr_screencopy_init(struct xdpw_state *state) {
 
 	logprint(DEBUG, "wayland: registry listeners run");
 
+	// make sure our wlroots supports xdg_output_manager
+	if (!ctx->xdg_output_manager) {
+		logprint(ERROR, "Compositor doesn't support %s!",
+			zxdg_output_manager_v1_interface.name);
+		return -1;
+	}
+
 	wlr_init_xdg_outputs(ctx);
 
 	wl_display_roundtrip(state->wl_display);


### PR DESCRIPTION
This reverts commit 94f1f5d0a8e9387057b643111d9909f25395fa10.

After fixing the #109 we probably can remove that check. Will test it the next days