### PR TITLE
Add wlroots to portal manifest UseIn list

### DIFF
--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
 Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=sway;Wayfire;river
+UseIn=wlroots;sway;Wayfire;river


### PR DESCRIPTION
XDG_CURRENT_DESKTOP can contain a list [1]. Allow users to
set a list such as XDG_CURRENT_DESKTOP=asdf:wlroots. That way, users
can use xdpw in their non-Sway compositor without specifying
XDG_CURRENT_DESKTOP=sway and without having to edit the portal
definition.

[1]: https://github.com/flatpak/xdg-desktop-portal/blob/9a2582d035a397efbb330c53f893d5649c1fd749/src/portal-impl.c#L189