### PR TITLE
Use inih instead of libiniparser

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -6,7 +6,7 @@ packages:
   - pipewire-dev
   - wayland-dev
   - wayland-protocols
-  - iniparser-dev
+  - inih-dev
   - scdoc
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -6,7 +6,7 @@ packages:
   - wayland
   - wayland-protocols
   - pipewire
-  - iniparser
+  - libinih
   - scdoc
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -7,7 +7,7 @@ packages:
   - pkgconf
   - wayland
   - wayland-protocols
-  - iniparser
+  - inih
   - scdoc
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,5 +1,5 @@
 [screencast]
 output_name=
 max_fps=30
-chooser_cmd="slurp -f %o -or"
+chooser_cmd=slurp -f %o -or
 chooser_type=simple

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ rt = cc.find_library('rt')
 pipewire = dependency('libpipewire-0.3', version: '>= 0.3.2')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
-iniparser = cc.find_library('iniparser', has_headers: ['iniparser.h', 'dictionary.h'])
+iniparser = dependency('inih')
 
 epoll = dependency('', required: false)
 if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -10,9 +10,12 @@
 #include <ini.h>
 
 void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config) {
-	logprint(loglevel, "config: outputname  %s", config->screencast_conf.output_name);
-	logprint(loglevel, "config: chooser_cmd: %s\n", config->screencast_conf.chooser_cmd);
-	logprint(loglevel, "config: chooser_type: %s\n", chooser_type_str(config->screencast_conf.chooser_type));
+	logprint(loglevel, "config: outputname:  %s", config->screencast_conf.output_name);
+	logprint(loglevel, "config: max_fps:  %d", config->screencast_conf.max_fps);
+	logprint(loglevel, "config: exec_before:  %s", config->screencast_conf.exec_before);
+	logprint(loglevel, "config: exec_after:  %s", config->screencast_conf.exec_after);
+	logprint(loglevel, "config: chooser_cmd: %s", config->screencast_conf.chooser_cmd);
+	logprint(loglevel, "config: chooser_type: %s", chooser_type_str(config->screencast_conf.chooser_type));
 }
 
 // NOTE: calling finish_config won't prepare the config to be read again from config file

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -82,6 +82,7 @@ int main(int argc, char *argv[]) {
 
 	init_logger(stderr, loglevel);
 	init_config(&configfile, &config);
+	print_config(DEBUG, &config);
 
 	int ret = 0;
 

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -28,7 +28,7 @@ max_fps=30
 exec_before=disable_notifications.sh
 exec_after=enable_notifications.sh
 chooser_type=simple
-chooser_cmd="slurp -f %o -or"
+chooser_cmd=slurp -f %o -or
 ```
 
 # SCREENCAST OPTIONS


### PR DESCRIPTION
Resolves: #96 

Note: inih doesn't escape quotes around a value, so this will break some configs.

#118 has made parsing much simpler.