### PR TITLE
Add -r flag to slurp

### DIFF
--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,5 +1,5 @@
 [screencast]
 output_name=
 max_fps=30
-chooser_cmd="slurp -f %o -o"
+chooser_cmd="slurp -f %o -or"
 chooser_type=simple

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -456,7 +456,7 @@ error_chooser_in:
 static struct xdpw_wlr_output *wlr_output_chooser_default(struct wl_list *output_list) {
 	logprint(DEBUG, "wlroots: output chooser called");
 	struct xdpw_output_chooser default_chooser[] = {
-		{XDPW_CHOOSER_SIMPLE, "slurp -f %o -o"},
+		{XDPW_CHOOSER_SIMPLE, "slurp -f %o -or"},
 		{XDPW_CHOOSER_DMENU, "wofi -d -n"},
 		{XDPW_CHOOSER_DMENU, "bemenu"},
 	};

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -28,7 +28,7 @@ max_fps=30
 exec_before=disable_notifications.sh
 exec_after=enable_notifications.sh
 chooser_type=simple
-chooser_cmd="slurp -f %o -o"
+chooser_cmd="slurp -f %o -or"
 ```
 
 # SCREENCAST OPTIONS


### PR DESCRIPTION
This prevents the user from selecting a custom region, and forces
them to select a full output.