### PR TITLE
contrib/systemd: add ConditionEnvironment

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-wlr.service.in
+++ b/contrib/systemd/xdg-desktop-portal-wlr.service.in
@@ -2,6 +2,7 @@
 Description=Portal service (wlroots implementation)
 PartOf=graphical-session.target
 After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=dbus


### PR DESCRIPTION
This makes it clear xdpw requires WAYLAND_DISPLAY to be set before
being started.

Inspired by the mako service [1].

[1]: https://github.com/emersion/mako/blob/master/contrib/systemd/mako.service