### PR TITLE
screencast: improve cleanup on error in xdpw_screencast_init()

### DIFF
--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -6,8 +6,8 @@
 #define XDPW_PWR_BUFFERS 1
 #define XDPW_PWR_ALIGN 16
 
-void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast);
-int xdpw_pwr_core_connect(struct xdpw_state *state);
+void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast);
+int xdpw_pwr_context_create(struct xdpw_state *state);
 
 #endif

--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -9,5 +9,6 @@
 void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast);
 int xdpw_pwr_context_create(struct xdpw_state *state);
+void xdpw_pwr_context_destroy(struct xdpw_state *state);
 
 #endif

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -230,6 +230,10 @@ int xdpw_pwr_context_create(struct xdpw_state *state) {
 }
 
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast) {
+	if (!cast->stream) {
+		return;
+	}
+
 	logprint(DEBUG, "pipewire: destroying stream");
 	pw_stream_flush(cast->stream, false);
 	pw_stream_disconnect(cast->stream);

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -136,7 +136,7 @@ static const struct pw_stream_events pwr_stream_events = {
 	.param_changed = pwr_handle_stream_param_changed,
 };
 
-void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast) {
+void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 	struct xdpw_screencast_context *ctx = cast->ctx;
 	struct xdpw_state *state = ctx->state;
 
@@ -206,7 +206,7 @@ void xdpw_pwr_stream_init(struct xdpw_screencast_instance *cast) {
 		&param, 1);
 }
 
-int xdpw_pwr_core_connect(struct xdpw_state *state) {
+int xdpw_pwr_context_create(struct xdpw_state *state) {
 	struct xdpw_screencast_context *ctx = &state->screencast;
 
 	logprint(DEBUG, "pipewire: establishing connection to core");

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -229,6 +229,22 @@ int xdpw_pwr_context_create(struct xdpw_state *state) {
 	return 0;
 }
 
+void xdpw_pwr_context_destroy(struct xdpw_state *state) {
+	struct xdpw_screencast_context *ctx = &state->screencast;
+
+	logprint(DEBUG, "pipewire: disconnecting fom core");
+
+	if (ctx->core) {
+		pw_core_disconnect(ctx->core);
+		ctx->core = NULL;
+	}
+
+	if (ctx->pwr_context) {
+		pw_context_destroy(ctx->pwr_context);
+		ctx->pwr_context = NULL;
+	}
+}
+
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast) {
 	if (!cast->stream) {
 		return;

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -206,6 +206,18 @@ void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 		&param, 1);
 }
 
+void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast) {
+	if (!cast->stream) {
+		return;
+	}
+
+	logprint(DEBUG, "pipewire: destroying stream");
+	pw_stream_flush(cast->stream, false);
+	pw_stream_disconnect(cast->stream);
+	pw_stream_destroy(cast->stream);
+	cast->stream = NULL;
+}
+
 int xdpw_pwr_context_create(struct xdpw_state *state) {
 	struct xdpw_screencast_context *ctx = &state->screencast;
 
@@ -243,16 +255,4 @@ void xdpw_pwr_context_destroy(struct xdpw_state *state) {
 		pw_context_destroy(ctx->pwr_context);
 		ctx->pwr_context = NULL;
 	}
-}
-
-void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast) {
-	if (!cast->stream) {
-		return;
-	}
-
-	logprint(DEBUG, "pipewire: destroying stream");
-	pw_stream_flush(cast->stream, false);
-	pw_stream_disconnect(cast->stream);
-	pw_stream_destroy(cast->stream);
-	cast->stream = NULL;
 }

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -134,7 +134,7 @@ static int start_screencast(struct xdpw_screencast_instance *cast) {
 	wl_display_dispatch(cast->ctx->state->wl_display);
 	wl_display_roundtrip(cast->ctx->state->wl_display);
 
-	xdpw_pwr_stream_init(cast);
+	xdpw_pwr_stream_create(cast);
 
 	cast->initialized = true;
 	return 0;
@@ -472,7 +472,7 @@ int xdpw_screencast_init(struct xdpw_state *state) {
 	state->screencast.state = state;
 
 	int err;
-	err = xdpw_pwr_core_connect(state);
+	err = xdpw_pwr_context_create(state);
 	if (err) {
 		goto end;
 	}

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -474,19 +474,22 @@ int xdpw_screencast_init(struct xdpw_state *state) {
 	int err;
 	err = xdpw_pwr_context_create(state);
 	if (err) {
-		goto end;
+		goto fail_pipewire;
 	}
 
 	err = xdpw_wlr_screencopy_init(state);
 	if (err) {
-		goto end;
+		goto fail_screencopy;
 	}
 
 	return sd_bus_add_object_vtable(state->bus, &slot, object_path, interface_name,
 		screencast_vtable, state);
 
-end:
-	// TODO: clean up pipewire
+fail_screencopy:
 	xdpw_wlr_screencopy_finish(&state->screencast);
+
+fail_pipewire:
+	xdpw_pwr_context_destroy(state);
+
 	return err;
 }


### PR DESCRIPTION
My idea how to fix #134. Probably needs review, and is only compile-tested atm.