### PR TITLE
ci: drop FreeBSD workaround after 22af25749e29

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -11,9 +11,6 @@ packages:
   - scdoc
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
-environment:
-  C_INCLUDE_PATH: /usr/local/include
-  LIBRARY_PATH: /usr/local/lib
 tasks:
   - setup: |
       cd xdg-desktop-portal-wlr


### PR DESCRIPTION
Follow up #126. inih exposes required CFLAGS/LDFLAGS via pkg-config, so hooking `/usr/local` is no longer necessary.