### PR TITLE
Handle POLLHUP

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -196,6 +196,19 @@ int main(int argc, char *argv[]) {
 			goto error;
 		}
 
+		if (pollfds[EVENT_LOOP_DBUS].revents & POLLHUP) {
+			logprint(INFO, "event-loop: disconnected from dbus");
+			break;
+		}
+		if (pollfds[EVENT_LOOP_WAYLAND].revents & POLLHUP) {
+			logprint(INFO, "event-loop: disconnected from wayland");
+			break;
+		}
+		if (pollfds[EVENT_LOOP_PIPEWIRE].revents & POLLHUP) {
+			logprint(INFO, "event-loop: disconnected from pipewire");
+			break;
+		}
+
 		if (pollfds[EVENT_LOOP_DBUS].revents & POLLIN) {
 			logprint(TRACE, "event-loop: got dbus event");
 			do {


### PR DESCRIPTION
This makes xdpw exit when either the D-Bus daemon, the Wayland
compositor or Pipewire is shut down. This avoids having dangling
non-functional xdpw instances, e.g. when restarting the compositor.

To test, start Sway nested in Sway, run xdpw with
WAYLAND_DISPLAY=wayland-2, and exit the nested Sway.