### PR TITLE
screencast: use negotiated maxFramerate from pipewire

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -96,7 +96,7 @@ struct xdpw_screencast_instance {
 	// wlroots
 	struct zwlr_screencopy_frame_v1 *frame_callback;
 	struct xdpw_wlr_output *target_output;
-	uint32_t framerate;
+	uint32_t max_framerate;
 	struct zwlr_screencopy_frame_v1 *wlr_frame;
 	struct xdpw_frame simple_frame;
 	bool with_cursor;

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -92,6 +92,7 @@ struct xdpw_screencast_instance {
 	uint32_t seq;
 	uint32_t node_id;
 	bool pwr_stream_state;
+	uint32_t framerate;
 
 	// wlroots
 	struct zwlr_screencopy_frame_v1 *frame_callback;

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -113,6 +113,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	}
 
 	spa_format_video_raw_parse(param, &cast->pwr_format);
+	cast->framerate = (uint32_t)(cast->pwr_format.max_framerate.num / cast->pwr_format.max_framerate.denom);
 
 	params[0] = spa_pod_builder_add_object(&b,
 		SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -189,9 +189,9 @@ void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 		SPA_POD_Fraction(&SPA_FRACTION(0, 1)), 0);
 	spa_pod_builder_add(&b, SPA_FORMAT_VIDEO_maxFramerate,
 		SPA_POD_CHOICE_RANGE_Fraction(
-			&SPA_FRACTION(cast->framerate, 1),
+			&SPA_FRACTION(cast->max_framerate, 1),
 			&SPA_FRACTION(1, 1),
-			&SPA_FRACTION(cast->framerate, 1)),
+			&SPA_FRACTION(cast->max_framerate, 1)),
 		0);
 	const struct spa_pod *param = spa_pod_builder_pop(&b, &f);
 

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -56,6 +56,7 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 	} else {
 		cast->max_framerate = (uint32_t)out->framerate;
 	}
+	cast->framerate = cast->max_framerate;
 	cast->with_cursor = with_cursor;
 	cast->refcount = 1;
 	logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -50,7 +50,12 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 
 	cast->ctx = ctx;
 	cast->target_output = out;
-	cast->framerate = out->framerate;
+	if (ctx->state->config->screencast_conf.max_fps > 0) {
+		cast->max_framerate = ctx->state->config->screencast_conf.max_fps < (uint32_t)out->framerate ?
+			ctx->state->config->screencast_conf.max_fps : (uint32_t)out->framerate;
+	} else {
+		cast->max_framerate = (uint32_t)out->framerate;
+	}
 	cast->with_cursor = with_cursor;
 	cast->refcount = 1;
 	logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -52,7 +52,7 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 		return ;
 	}
 
-	uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->ctx->state->config->screencast_conf.max_fps);
+	uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->max_framerate);
 	if (delay_ns > 0) {
 		xdpw_add_timer(cast->ctx->state, delay_ns,
 			(xdpw_event_loop_timer_func_t) xdpw_wlr_register_cb, cast);
@@ -144,7 +144,7 @@ static void wlr_frame_buffer_done(void *data,
 	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->simple_frame.buffer);
 	logprint(TRACE, "wlroots: frame copied");
 
-	fps_limit_measure_start(&cast->fps_limit, cast->ctx->state->config->screencast_conf.max_fps);
+	fps_limit_measure_start(&cast->fps_limit, cast->max_framerate);
 }
 
 static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -52,7 +52,7 @@ void xdpw_wlr_frame_free(struct xdpw_screencast_instance *cast) {
 		return ;
 	}
 
-	uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->max_framerate);
+	uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
 	if (delay_ns > 0) {
 		xdpw_add_timer(cast->ctx->state, delay_ns,
 			(xdpw_event_loop_timer_func_t) xdpw_wlr_register_cb, cast);
@@ -144,7 +144,7 @@ static void wlr_frame_buffer_done(void *data,
 	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->simple_frame.buffer);
 	logprint(TRACE, "wlroots: frame copied");
 
-	fps_limit_measure_start(&cast->fps_limit, cast->max_framerate);
+	fps_limit_measure_start(&cast->fps_limit, cast->framerate);
 }
 
 static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,


### PR DESCRIPTION
Read the negotiated maxFramerate from pipewire and use that for our timer to prevent unnecessary screencopies. 

I don't know any usefull client, which announces maxFramerate yet, but hardcoding them in obs-studio worked.