### PR TITLE
Fix potential memory corruption when reading bools

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -267,9 +267,9 @@ static int method_screencast_select_sources(sd_bus_message *msg, void *data,
 		}
 
 		if (strcmp(key, "multiple") == 0) {
-			bool multiple;
+			int multiple;
 			sd_bus_message_read(msg, "v", "b", &multiple);
-			logprint(INFO, "dbus: option multiple: %x", multiple);
+			logprint(INFO, "dbus: option multiple: %d", multiple);
 		} else if (strcmp(key, "types") == 0) {
 			uint32_t mask;
 			sd_bus_message_read(msg, "v", "u", &mask);

--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -83,14 +83,14 @@ static int method_screenshot(sd_bus_message *msg, void *data,
 		}
 
 		if (strcmp(key, "interactive") == 0) {
-			bool mode;
+			int mode;
 			sd_bus_message_read(msg, "v", "b", &mode);
-			logprint(DEBUG, "dbus: option interactive: %x", mode);
+			logprint(DEBUG, "dbus: option interactive: %d", mode);
 			interactive = mode;
 		} else if (strcmp(key, "modal") == 0) {
-			bool modal;
+			int modal;
 			sd_bus_message_read(msg, "v", "b", &modal);
-			logprint(DEBUG, "dbus: option modal: %x", modal);
+			logprint(DEBUG, "dbus: option modal: %d", modal);
 		} else {
 			logprint(WARN, "dbus: unknown option %s", key);
 			sd_bus_message_skip(msg, "v");


### PR DESCRIPTION
As per `man sd_bus_message_read`, boolean items should be read into an int rather than a bool as the latter can cause memory corruption.

(I'm not sure if this currently causes any issues in xdpw, but I did encounter this bug in a portal I'm writing that's based on xdpw.)
