### PR TITLE
Support cropping via pipewire

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -12,6 +12,8 @@ struct config_screencast {
 	char *chooser_cmd;
 	enum xdpw_chooser_types chooser_type;
 	bool force_mod_linear;
+	enum xdpw_cropmode cropmode;
+	struct xdpw_frame_crop region;
 };
 
 struct xdpw_config {

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -70,6 +70,12 @@ struct xdpw_frame_crop {
 	uint32_t height;
 };
 
+enum xdpw_cropmode {
+	XDPW_CROP_NONE,
+	XDPW_CROP_WLROOTS,
+	XDPW_CROP_PIPEWIRE,
+};
+
 struct xdpw_frame {
 	bool y_invert;
 	uint64_t tv_sec;
@@ -167,6 +173,7 @@ struct xdpw_screencast_instance {
 	enum xdpw_frame_state frame_state;
 	struct wl_list buffer_list;
 	bool avoid_dmabufs;
+	enum xdpw_cropmode cropmode;
 
 	// pipewire
 	struct pw_stream *stream;

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -63,12 +63,20 @@ struct xdpw_frame_damage {
 	uint32_t height;
 };
 
+struct xdpw_frame_crop {
+	uint32_t x;
+	uint32_t y;
+	uint32_t width;
+	uint32_t height;
+};
+
 struct xdpw_frame {
 	bool y_invert;
 	uint64_t tv_sec;
 	uint32_t tv_nsec;
 	struct xdpw_frame_damage damage[4];
 	uint32_t damage_count;
+	struct xdpw_frame_crop crop;
 	struct xdpw_buffer *xdpw_buffer;
 	struct pw_buffer *pw_buffer;
 };

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -234,4 +234,5 @@ enum xdpw_chooser_types get_chooser_type(const char *chooser_type);
 const char *chooser_type_str(enum xdpw_chooser_types chooser_type);
 
 struct xdpw_frame_damage merge_damage(struct xdpw_frame_damage *damage1, struct xdpw_frame_damage *damage2);
+const char *cropmode_str(enum xdpw_cropmode cropmode);
 #endif /* SCREENCAST_COMMON_H */

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -499,7 +499,7 @@ void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast) {
 	}
 
 	struct spa_meta_region *crop;
-	if ((crop = spa_buffer_find_meta_data(spa_buf, SPA_META_VideoCrop, sizeof(*crop)))) {
+	if (cast->cropmode == XDPW_CROP_PIPEWIRE && (crop = spa_buffer_find_meta_data(spa_buf, SPA_META_VideoCrop, sizeof(*crop)))) {
 		crop->region.position.x = cast->current_frame.crop.x;
 		crop->region.position.y = cast->current_frame.crop.y;
 		crop->region.size.width = cast->current_frame.crop.width;

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -203,7 +203,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	struct pw_stream *stream = cast->stream;
 	uint8_t params_buffer[3][1024];
 	struct spa_pod_dynamic_builder b[3];
-	const struct spa_pod *params[4];
+	const struct spa_pod *params[5];
 	uint32_t blocks;
 	uint32_t data_type;
 
@@ -330,7 +330,12 @@ fixate_format:
 			sizeof(struct spa_meta_region) * 1,
 			sizeof(struct spa_meta_region) * 4));
 
-	pw_stream_update_params(stream, params, 4);
+	params[4] = spa_pod_builder_add_object(&b[2].b,
+		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
+		SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoCrop),
+		SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_region)));
+
+	pw_stream_update_params(stream, params, 5);
 	spa_pod_dynamic_builder_clean(&b[0]);
 	spa_pod_dynamic_builder_clean(&b[1]);
 	spa_pod_dynamic_builder_clean(&b[2]);
@@ -493,6 +498,14 @@ void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast) {
 		}
 	}
 
+	struct spa_meta_region *crop;
+	if ((crop = spa_buffer_find_meta_data(spa_buf, SPA_META_VideoCrop, sizeof(*crop)))) {
+		crop->region.position.x = cast->current_frame.crop.x;
+		crop->region.position.y = cast->current_frame.crop.y;
+		crop->region.size.width = cast->current_frame.crop.width;
+		crop->region.size.height = cast->current_frame.crop.height;
+	}
+
 	if (buffer_corrupt) {
 		for (uint32_t plane = 0; plane < spa_buf->n_datas; plane++) {
 			d[plane].chunk->flags = SPA_CHUNK_FLAG_CORRUPTED;
@@ -515,6 +528,9 @@ void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast) {
 	logprint(TRACE, "pipewire: width %d", cast->current_frame.xdpw_buffer->width);
 	logprint(TRACE, "pipewire: height %d", cast->current_frame.xdpw_buffer->height);
 	logprint(TRACE, "pipewire: y_invert %d", cast->current_frame.y_invert);
+	logprint(TRACE, "pipewire: crop %u,%u (%ux%u)",
+			cast->current_frame.crop.x, cast->current_frame.crop.y,
+			cast->current_frame.crop.width, cast->current_frame.crop.height);
 	logprint(TRACE, "********************");
 
 	pw_stream_queue_buffer(cast->stream, pw_buf);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -73,6 +73,16 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 	cast->avoid_dmabufs = false;
 	cast->teardown = false;
 	wl_list_init(&cast->buffer_list);
+	if (ctx->state->config->screencast_conf.chooser_type == XDPW_CHOOSER_NONE &&
+			ctx->state->config->screencast_conf.cropmode != XDPW_CROP_NONE &&
+			ctx->state->config->screencast_conf.region.width != 0 &&
+			ctx->state->config->screencast_conf.region.height != 0) {
+		cast->cropmode = ctx->state->config->screencast_conf.cropmode;
+		cast->current_frame.crop.x = ctx->state->config->screencast_conf.region.x;
+		cast->current_frame.crop.y = ctx->state->config->screencast_conf.region.y;
+		cast->current_frame.crop.width = ctx->state->config->screencast_conf.region.width;
+		cast->current_frame.crop.height = ctx->state->config->screencast_conf.region.height;
+	}
 	logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);
 	wl_list_insert(&ctx->screencast_instances, &cast->link);
 	logprint(INFO, "xdpw: %d active screencast instances",

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -424,3 +424,16 @@ struct xdpw_frame_damage merge_damage(struct xdpw_frame_damage *damage1, struct 
 
 	return damage;
 }
+
+const char *cropmode_str(enum xdpw_cropmode cropmode) {
+	switch (cropmode) {
+	case XDPW_CROP_NONE:
+		return "none";
+	case XDPW_CROP_WLROOTS:
+		return "wlroots";
+	case XDPW_CROP_PIPEWIRE:
+		return "pipewire";
+	}
+	fprintf(stderr, "Could not find chooser type %d\n", cropmode);
+	abort();
+}

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -252,8 +252,17 @@ static const struct zwlr_screencopy_frame_v1_listener wlr_frame_listener = {
 };
 
 void xdpw_wlr_register_cb(struct xdpw_screencast_instance *cast) {
-	cast->frame_callback = zwlr_screencopy_manager_v1_capture_output(
-		cast->ctx->screencopy_manager, cast->target->with_cursor, cast->target->output->output);
+	switch (cast->cropmode) {
+	case XDPW_CROP_WLROOTS:
+		cast->frame_callback = zwlr_screencopy_manager_v1_capture_output_region(
+			cast->ctx->screencopy_manager, cast->target->with_cursor, cast->target->output->output,
+			cast->current_frame.crop.x, cast->current_frame.crop.y,
+			cast->current_frame.crop.width, cast->current_frame.crop.height);
+		break;
+	default:
+		cast->frame_callback = zwlr_screencopy_manager_v1_capture_output(
+			cast->ctx->screencopy_manager, cast->target->with_cursor, cast->target->output->output);
+	}
 
 	zwlr_screencopy_frame_v1_add_listener(cast->frame_callback,
 		&wlr_frame_listener, cast);

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -80,6 +80,17 @@ These options need to be placed under the **[screencast]** section.
 
 	This option is experimental and can be removed or replaced in future versions.
 
+**cropmode** = _type_
+	Specifies the mode to crop the output to the defined region.
+
+	The supported types are:
+	- none: No cropping, ignore region.
+	- wlroots: Crop inside the compositor. Better performance.
+	- pipewire: Send cropping information via PipeWire.
+
+**region** = _offset_x_,_offset_y_:_width_x_height_
+	Specifies the region the output is cropped to. Only works with **chooser_type** = none.
+
 ## OUTPUT CHOOSER
 
 The chooser can be any program or script with the following behaviour:


### PR DESCRIPTION
Depends: #141 

Blockers:
* [ ] Add an region option in the config file to be used with `output_name` and `chooser_type = none`
* [ ] Extend the protocol between the chooser and xdpw to support a region.
* [ ] Create a patch for [slurp](https://github.com/emersion/slurp) to output coordinates wrt. to the screen (local coordinates)