### PR TITLE
Dmabuf modifierless

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -8,6 +8,8 @@ packages:
   - wayland-protocols
   - inih-dev
   - scdoc
+  - libdrm
+  - mesa-dev
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -8,6 +8,7 @@ packages:
   - pipewire
   - libinih
   - scdoc
+  - mesa
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -9,6 +9,8 @@ packages:
   - wayland-protocols
   - inih
   - scdoc
+  - graphics/libdrm
+  - graphics/mesa-libs
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/include/config.h
+++ b/include/config.h
@@ -11,6 +11,7 @@ struct config_screencast {
 	char *exec_after;
 	char *chooser_cmd;
 	enum xdpw_chooser_types chooser_type;
+	bool force_mod_linear;
 };
 
 struct xdpw_config {

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -1,6 +1,7 @@
 #ifndef SCREENCAST_COMMON_H
 #define SCREENCAST_COMMON_H
 
+#include <gbm.h>
 #include <pipewire/pipewire.h>
 #include <spa/param/video/format-utils.h>
 #include <wayland-client-protocol.h>
@@ -103,6 +104,9 @@ struct xdpw_screencast_context {
 	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_shm *shm;
 
+	// gbm
+	struct gbm_device *gbm;
+
 	// sessions
 	struct wl_list screencast_instances;
 };
@@ -158,6 +162,7 @@ struct xdpw_wlr_output {
 };
 
 void randname(char *buf);
+struct gbm_device *xdpw_gbm_device_create(void);
 struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 	enum buffer_type buffer_type, struct xdpw_screencopy_frame_info *frame_info);
 void xdpw_buffer_destroy(struct xdpw_buffer *buffer);

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -22,6 +22,11 @@ enum source_types {
   WINDOW = 2,
 };
 
+enum buffer_type {
+  WL_SHM = 0,
+  DMABUF = 1,
+};
+
 enum xdpw_chooser_types {
   XDPW_CHOOSER_DEFAULT,
   XDPW_CHOOSER_NONE,
@@ -68,6 +73,7 @@ struct xdpw_screencopy_frame_info {
 
 struct xdpw_buffer {
 	struct wl_list link;
+	enum buffer_type buffer_type;
 
 	uint32_t width;
 	uint32_t height;
@@ -127,11 +133,12 @@ struct xdpw_screencast_instance {
 	struct xdpw_wlr_output *target_output;
 	uint32_t max_framerate;
 	struct zwlr_screencopy_frame_v1 *wlr_frame;
-	struct xdpw_screencopy_frame_info screencopy_frame_info;
+	struct xdpw_screencopy_frame_info screencopy_frame_info[2];
 	bool with_cursor;
 	int err;
 	bool quit;
 	bool need_buffer;
+	enum buffer_type buffer_type;
 
 	// fps limit
 	struct fps_limit_state fps_limit;
@@ -152,7 +159,7 @@ struct xdpw_wlr_output {
 
 void randname(char *buf);
 struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
-	struct xdpw_screencopy_frame_info *frame_info);
+	enum buffer_type buffer_type, struct xdpw_screencopy_frame_info *frame_info);
 void xdpw_buffer_destroy(struct xdpw_buffer *buffer);
 enum wl_shm_format xdpw_format_wl_shm_from_drm_fourcc(uint32_t format);
 uint32_t xdpw_format_drm_fourcc_from_wl_shm(enum wl_shm_format format);

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -103,6 +103,7 @@ struct xdpw_screencast_context {
 	struct zwlr_screencopy_manager_v1 *screencopy_manager;
 	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_shm *shm;
+	struct zwp_linux_dmabuf_v1 *linux_dmabuf;
 
 	// gbm
 	struct gbm_device *gbm;

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -63,7 +63,7 @@ struct xdpw_screencopy_frame_info {
 	uint32_t height;
 	uint32_t size;
 	uint32_t stride;
-	enum wl_shm_format format;
+	uint32_t format;
 };
 
 struct xdpw_buffer {
@@ -71,7 +71,7 @@ struct xdpw_buffer {
 
 	uint32_t width;
 	uint32_t height;
-	enum wl_shm_format format;
+	uint32_t format;
 
 	int fd;
 	uint32_t size;
@@ -154,7 +154,9 @@ void randname(char *buf);
 struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 	struct xdpw_screencopy_frame_info *frame_info);
 void xdpw_buffer_destroy(struct xdpw_buffer *buffer);
-enum spa_video_format xdpw_format_pw_from_wl_shm(enum wl_shm_format format);
+enum wl_shm_format xdpw_format_wl_shm_from_drm_fourcc(uint32_t format);
+uint32_t xdpw_format_drm_fourcc_from_wl_shm(enum wl_shm_format format);
+enum spa_video_format xdpw_format_pw_from_drm_fourcc(uint32_t format);
 enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format);
 
 enum xdpw_chooser_types get_chooser_type(const char *chooser_type);

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -85,6 +85,8 @@ struct xdpw_buffer {
 	uint32_t stride;
 	uint32_t offset;
 
+	struct gbm_bo *bo;
+
 	struct wl_buffer *buffer;
 };
 

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -12,6 +12,8 @@
 
 #define XDG_OUTPUT_MANAGER_VERSION 3
 
+#define LINUX_DMABUF_VERSION 3
+
 struct xdpw_state;
 
 int xdpw_wlr_screencopy_init(struct xdpw_state *state);

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,8 @@ pipewire = dependency('libpipewire-0.3', version: '>= 0.3.41')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 iniparser = dependency('inih')
+gbm = dependency('gbm')
+drm = dependency('libdrm')
 
 epoll = dependency('', required: false)
 if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
@@ -92,6 +94,8 @@ executable(
 		pipewire,
 		rt,
 		iniparser,
+		gbm,
+		drm,
 		epoll,
 	],
 	include_directories: [inc],

--- a/protocols/linux-dmabuf-unstable-v1.xml
+++ b/protocols/linux-dmabuf-unstable-v1.xml
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="linux_dmabuf_unstable_v1">
+
+	<copyright>
+		Copyright © 2014, 2015 Collabora, Ltd.
+
+		Permission is hereby granted, free of charge, to any person obtaining a
+		copy of this software and associated documentation files (the "Software"),
+		to deal in the Software without restriction, including without limitation
+		the rights to use, copy, modify, merge, publish, distribute, sublicense,
+		and/or sell copies of the Software, and to permit persons to whom the
+		Software is furnished to do so, subject to the following conditions:
+
+		The above copyright notice and this permission notice (including the next
+		paragraph) shall be included in all copies or substantial portions of the
+		Software.
+
+		THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+		IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+		FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+		THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+		LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+		FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+		DEALINGS IN THE SOFTWARE.
+	</copyright>
+
+	<interface name="zwp_linux_dmabuf_v1" version="3">
+		<description summary="factory for creating dmabuf-based wl_buffers">
+			Following the interfaces from:
+			https://www.khronos.org/registry/egl/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
+			https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
+			and the Linux DRM sub-system's AddFb2 ioctl.
+
+			This interface offers ways to create generic dmabuf-based
+			wl_buffers. Immediately after a client binds to this interface,
+			the set of supported formats and format modifiers is sent with
+			'format' and 'modifier' events.
+
+			The following are required from clients:
+
+			- Clients must ensure that either all data in the dma-buf is
+				coherent for all subsequent read access or that coherency is
+				correctly handled by the underlying kernel-side dma-buf
+				implementation.
+
+			- Don't make any more attachments after sending the buffer to the
+				compositor. Making more attachments later increases the risk of
+				the compositor not being able to use (re-import) an existing
+				dmabuf-based wl_buffer.
+
+			The underlying graphics stack must ensure the following:
+
+			- The dmabuf file descriptors relayed to the server will stay valid
+				for the whole lifetime of the wl_buffer. This means the server may
+				at any time use those fds to import the dmabuf into any kernel
+				sub-system that might accept it.
+
+			To create a wl_buffer from one or more dmabufs, a client creates a
+			zwp_linux_dmabuf_params_v1 object with a zwp_linux_dmabuf_v1.create_params
+			request. All planes required by the intended format are added with
+			the 'add' request. Finally, a 'create' or 'create_immed' request is
+			issued, which has the following outcome depending on the import success.
+
+			The 'create' request,
+			- on success, triggers a 'created' event which provides the final
+				wl_buffer to the client.
+			- on failure, triggers a 'failed' event to convey that the server
+				cannot use the dmabufs received from the client.
+
+			For the 'create_immed' request,
+			- on success, the server immediately imports the added dmabufs to
+				create a wl_buffer. No event is sent from the server in this case.
+			- on failure, the server can choose to either:
+				- terminate the client by raising a fatal error.
+				- mark the wl_buffer as failed, and send a 'failed' event to the
+					client. If the client uses a failed wl_buffer as an argument to any
+					request, the behaviour is compositor implementation-defined.
+
+			Warning! The protocol described in this file is experimental and
+			backward incompatible changes may be made. Backward compatible changes
+			may be added together with the corresponding interface version bump.
+			Backward incompatible changes are done by bumping the version number in
+			the protocol and interface names and resetting the interface version.
+			Once the protocol is to be declared stable, the 'z' prefix and the
+			version number in the protocol and interface names are removed and the
+			interface version number is reset.
+		</description>
+
+		<request name="destroy" type="destructor">
+			<description summary="unbind the factory">
+				Objects created through this interface, especially wl_buffers, will
+				remain valid.
+			</description>
+		</request>
+
+		<request name="create_params">
+			<description summary="create a temporary object for buffer parameters">
+				This temporary object is used to collect multiple dmabuf handles into
+				a single batch to create a wl_buffer. It can only be used once and
+				should be destroyed after a 'created' or 'failed' event has been
+				received.
+			</description>
+			<arg name="params_id" type="new_id" interface="zwp_linux_buffer_params_v1"
+					 summary="the new temporary"/>
+		</request>
+
+		<event name="format">
+			<description summary="supported buffer format">
+				This event advertises one buffer format that the server supports.
+				All the supported formats are advertised once when the client
+				binds to this interface. A roundtrip after binding guarantees
+				that the client has received all supported formats.
+
+				For the definition of the format codes, see the
+				zwp_linux_buffer_params_v1::create request.
+
+				Warning: the 'format' event is likely to be deprecated and replaced
+				with the 'modifier' event introduced in zwp_linux_dmabuf_v1
+				version 3, described below. Please refrain from using the information
+				received from this event.
+			</description>
+			<arg name="format" type="uint" summary="DRM_FORMAT code"/>
+		</event>
+
+		<event name="modifier" since="3">
+			<description summary="supported buffer format modifier">
+				This event advertises the formats that the server supports, along with
+				the modifiers supported for each format. All the supported modifiers
+				for all the supported formats are advertised once when the client
+				binds to this interface. A roundtrip after binding guarantees that
+				the client has received all supported format-modifier pairs.
+
+				For legacy support, DRM_FORMAT_MOD_INVALID (that is, modifier_hi ==
+				0x00ffffff and modifier_lo == 0xffffffff) is allowed in this event.
+				It indicates that the server can support the format with an implicit
+				modifier. When a plane has DRM_FORMAT_MOD_INVALID as its modifier, it
+				is as if no explicit modifier is specified. The effective modifier
+				will be derived from the dmabuf.
+
+				For the definition of the format and modifier codes, see the
+				zwp_linux_buffer_params_v1::create and zwp_linux_buffer_params_v1::add
+				requests.
+			</description>
+			<arg name="format" type="uint" summary="DRM_FORMAT code"/>
+			<arg name="modifier_hi" type="uint"
+					 summary="high 32 bits of layout modifier"/>
+			<arg name="modifier_lo" type="uint"
+					 summary="low 32 bits of layout modifier"/>
+		</event>
+	</interface>
+
+	<interface name="zwp_linux_buffer_params_v1" version="3">
+		<description summary="parameters for creating a dmabuf-based wl_buffer">
+			This temporary object is a collection of dmabufs and other
+			parameters that together form a single logical buffer. The temporary
+			object may eventually create one wl_buffer unless cancelled by
+			destroying it before requesting 'create'.
+
+			Single-planar formats only require one dmabuf, however
+			multi-planar formats may require more than one dmabuf. For all
+			formats, an 'add' request must be called once per plane (even if the
+			underlying dmabuf fd is identical).
+
+			You must use consecutive plane indices ('plane_idx' argument for 'add')
+			from zero to the number of planes used by the drm_fourcc format code.
+			All planes required by the format must be given exactly once, but can
+			be given in any order. Each plane index can be set only once.
+		</description>
+
+		<enum name="error">
+			<entry name="already_used" value="0"
+						 summary="the dmabuf_batch object has already been used to create a wl_buffer"/>
+			<entry name="plane_idx" value="1"
+						 summary="plane index out of bounds"/>
+			<entry name="plane_set" value="2"
+						 summary="the plane index was already set"/>
+			<entry name="incomplete" value="3"
+						 summary="missing or too many planes to create a buffer"/>
+			<entry name="invalid_format" value="4"
+						 summary="format not supported"/>
+			<entry name="invalid_dimensions" value="5"
+						 summary="invalid width or height"/>
+			<entry name="out_of_bounds" value="6"
+						 summary="offset + stride * height goes out of dmabuf bounds"/>
+			<entry name="invalid_wl_buffer" value="7"
+						 summary="invalid wl_buffer resulted from importing dmabufs via
+							 the create_immed request on given buffer_params"/>
+		</enum>
+
+		<request name="destroy" type="destructor">
+			<description summary="delete this object, used or not">
+				Cleans up the temporary data sent to the server for dmabuf-based
+				wl_buffer creation.
+			</description>
+		</request>
+
+		<request name="add">
+			<description summary="add a dmabuf to the temporary set">
+				This request adds one dmabuf to the set in this
+				zwp_linux_buffer_params_v1.
+
+				The 64-bit unsigned value combined from modifier_hi and modifier_lo
+				is the dmabuf layout modifier. DRM AddFB2 ioctl calls this the
+				fb modifier, which is defined in drm_mode.h of Linux UAPI.
+				This is an opaque token. Drivers use this token to express tiling,
+				compression, etc. driver-specific modifications to the base format
+				defined by the DRM fourcc code.
+
+				Warning: It should be an error if the format/modifier pair was not
+				advertised with the modifier event. This is not enforced yet because
+				some implementations always accept DRM_FORMAT_MOD_INVALID. Also
+				version 2 of this protocol does not have the modifier event.
+
+				This request raises the PLANE_IDX error if plane_idx is too large.
+				The error PLANE_SET is raised if attempting to set a plane that
+				was already set.
+			</description>
+			<arg name="fd" type="fd" summary="dmabuf fd"/>
+			<arg name="plane_idx" type="uint" summary="plane index"/>
+			<arg name="offset" type="uint" summary="offset in bytes"/>
+			<arg name="stride" type="uint" summary="stride in bytes"/>
+			<arg name="modifier_hi" type="uint"
+					 summary="high 32 bits of layout modifier"/>
+			<arg name="modifier_lo" type="uint"
+					 summary="low 32 bits of layout modifier"/>
+		</request>
+
+		<enum name="flags">
+			<entry name="y_invert" value="1" summary="contents are y-inverted"/>
+			<entry name="interlaced" value="2" summary="content is interlaced"/>
+			<entry name="bottom_first" value="4" summary="bottom field first"/>
+		</enum>
+
+		<request name="create">
+			<description summary="create a wl_buffer from the given dmabufs">
+				This asks for creation of a wl_buffer from the added dmabuf
+				buffers. The wl_buffer is not created immediately but returned via
+				the 'created' event if the dmabuf sharing succeeds. The sharing
+				may fail at runtime for reasons a client cannot predict, in
+				which case the 'failed' event is triggered.
+
+				The 'format' argument is a DRM_FORMAT code, as defined by the
+				libdrm's drm_fourcc.h. The Linux kernel's DRM sub-system is the
+				authoritative source on how the format codes should work.
+
+				The 'flags' is a bitfield of the flags defined in enum "flags".
+				'y_invert' means the that the image needs to be y-flipped.
+
+				Flag 'interlaced' means that the frame in the buffer is not
+				progressive as usual, but interlaced. An interlaced buffer as
+				supported here must always contain both top and bottom fields.
+				The top field always begins on the first pixel row. The temporal
+				ordering between the two fields is top field first, unless
+				'bottom_first' is specified. It is undefined whether 'bottom_first'
+				is ignored if 'interlaced' is not set.
+
+				This protocol does not convey any information about field rate,
+				duration, or timing, other than the relative ordering between the
+				two fields in one buffer. A compositor may have to estimate the
+				intended field rate from the incoming buffer rate. It is undefined
+				whether the time of receiving wl_surface.commit with a new buffer
+				attached, applying the wl_surface state, wl_surface.frame callback
+				trigger, presentation, or any other point in the compositor cycle
+				is used to measure the frame or field times. There is no support
+				for detecting missed or late frames/fields/buffers either, and
+				there is no support whatsoever for cooperating with interlaced
+				compositor output.
+
+				The composited image quality resulting from the use of interlaced
+				buffers is explicitly undefined. A compositor may use elaborate
+				hardware features or software to deinterlace and create progressive
+				output frames from a sequence of interlaced input buffers, or it
+				may produce substandard image quality. However, compositors that
+				cannot guarantee reasonable image quality in all cases are recommended
+				to just reject all interlaced buffers.
+
+				Any argument errors, including non-positive width or height,
+				mismatch between the number of planes and the format, bad
+				format, bad offset or stride, may be indicated by fatal protocol
+				errors: INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS,
+				OUT_OF_BOUNDS.
+
+				Dmabuf import errors in the server that are not obvious client
+				bugs are returned via the 'failed' event as non-fatal. This
+				allows attempting dmabuf sharing and falling back in the client
+				if it fails.
+
+				This request can be sent only once in the object's lifetime, after
+				which the only legal request is destroy. This object should be
+				destroyed after issuing a 'create' request. Attempting to use this
+				object after issuing 'create' raises ALREADY_USED protocol error.
+
+				It is not mandatory to issue 'create'. If a client wants to
+				cancel the buffer creation, it can just destroy this object.
+			</description>
+			<arg name="width" type="int" summary="base plane width in pixels"/>
+			<arg name="height" type="int" summary="base plane height in pixels"/>
+			<arg name="format" type="uint" summary="DRM_FORMAT code"/>
+			<arg name="flags" type="uint" summary="see enum flags"/>
+		</request>
+
+		<event name="created">
+			<description summary="buffer creation succeeded">
+				This event indicates that the attempted buffer creation was
+				successful. It provides the new wl_buffer referencing the dmabuf(s).
+
+				Upon receiving this event, the client should destroy the
+				zlinux_dmabuf_params object.
+			</description>
+			<arg name="buffer" type="new_id" interface="wl_buffer"
+					 summary="the newly created wl_buffer"/>
+		</event>
+
+		<event name="failed">
+			<description summary="buffer creation failed">
+				This event indicates that the attempted buffer creation has
+				failed. It usually means that one of the dmabuf constraints
+				has not been fulfilled.
+
+				Upon receiving this event, the client should destroy the
+				zlinux_buffer_params object.
+			</description>
+		</event>
+
+		<request name="create_immed" since="2">
+			<description summary="immediately create a wl_buffer from the given
+										 dmabufs">
+				This asks for immediate creation of a wl_buffer by importing the
+				added dmabufs.
+
+				In case of import success, no event is sent from the server, and the
+				wl_buffer is ready to be used by the client.
+
+				Upon import failure, either of the following may happen, as seen fit
+				by the implementation:
+				- the client is terminated with one of the following fatal protocol
+					errors:
+					- INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS, OUT_OF_BOUNDS,
+						in case of argument errors such as mismatch between the number
+						of planes and the format, bad format, non-positive width or
+						height, or bad offset or stride.
+					- INVALID_WL_BUFFER, in case the cause for failure is unknown or
+						plaform specific.
+				- the server creates an invalid wl_buffer, marks it as failed and
+					sends a 'failed' event to the client. The result of using this
+					invalid wl_buffer as an argument in any request by the client is
+					defined by the compositor implementation.
+
+				This takes the same arguments as a 'create' request, and obeys the
+				same restrictions.
+			</description>
+			<arg name="buffer_id" type="new_id" interface="wl_buffer"
+					 summary="id for the newly created wl_buffer"/>
+			<arg name="width" type="int" summary="base plane width in pixels"/>
+			<arg name="height" type="int" summary="base plane height in pixels"/>
+			<arg name="format" type="uint" summary="DRM_FORMAT code"/>
+			<arg name="flags" type="uint" summary="see enum flags"/>
+		</request>
+
+	</interface>
+
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -9,6 +9,7 @@ else
 endif
 
 client_protocols = [
+	'linux-dmabuf-unstable-v1.xml',
 	'wlr-screencopy-unstable-v1.xml',
 	'xdg-output-unstable-v1.xml',
 ]

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -16,6 +16,7 @@ void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config) {
 	logprint(loglevel, "config: exec_after:  %s", config->screencast_conf.exec_after);
 	logprint(loglevel, "config: chooser_cmd: %s", config->screencast_conf.chooser_cmd);
 	logprint(loglevel, "config: chooser_type: %s", chooser_type_str(config->screencast_conf.chooser_type));
+	logprint(loglevel, "config: force_mod_linear: %d", config->screencast_conf.force_mod_linear);
 }
 
 // NOTE: calling finish_config won't prepare the config to be read again from config file
@@ -47,6 +48,18 @@ static void parse_double(double *dest, const char* value) {
 	*dest = strtod(value, (char**)NULL);
 }
 
+static void parse_bool(bool *dest, const char* value) {
+	if (value == NULL || *value == '\0') {
+		logprint(TRACE, "config: skipping empty value in config file");
+		return;
+	}
+	if (strcmp(value, "1") == 0) {
+		*dest = true;
+	} else {
+		*dest = false;
+	}
+}
+
 static int handle_ini_screencast(struct config_screencast *screencast_conf, const char *key, const char *value) {
 	if (strcmp(key, "output_name") == 0) {
 		parse_string(&screencast_conf->output_name, value);
@@ -63,6 +76,8 @@ static int handle_ini_screencast(struct config_screencast *screencast_conf, cons
 		parse_string(&chooser_type, value);
 		screencast_conf->chooser_type = get_chooser_type(chooser_type);
 		free(chooser_type);
+	} else if (strcmp(key, "force_mod_linear") == 0) {
+		parse_bool(&screencast_conf->force_mod_linear, value);
 	} else {
 		logprint(TRACE, "config: skipping invalid key in config file");
 		return 0;

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -233,6 +233,12 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	d[0].flags = 0;
 	d[0].fd = xdpw_buffer->fd;
 	d[0].data = NULL;
+
+	// clients have implemented to check chunk->size if the buffer is valid instead
+	// of using the flags. Until they are patched we should use some arbitrary value.
+	if (xdpw_buffer->buffer_type == DMABUF && d[0].chunk->size == 0) {
+		d[0].chunk->size = 9; // This was choosen by a fair d20.
+	}
 }
 
 static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer) {

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -186,6 +186,9 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	if ((d[0].type & (1u << SPA_DATA_MemFd)) > 0) {
 		assert(cast->buffer_type == WL_SHM);
 		d[0].type = SPA_DATA_MemFd;
+	} else if ((d[0].type & (1u << SPA_DATA_DmaBuf)) > 0) {
+		assert(cast->buffer_type == DMABUF);
+		d[0].type = SPA_DATA_DmaBuf;
 	} else {
 		logprint(ERROR, "pipewire: unsupported buffer type");
 		cast->err = 1;

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -268,7 +268,7 @@ void pwr_update_stream_param(struct xdpw_screencast_instance *cast) {
 		SPA_POD_BUILDER_INIT(params_buffer, sizeof(params_buffer));
 	const struct spa_pod *params[1];
 
-	enum spa_video_format format = xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format);
+	enum spa_video_format format = xdpw_format_pw_from_drm_fourcc(cast->screencopy_frame_info.format);
 
 	params[0] = build_format(&b, format,
 			cast->screencopy_frame_info.width, cast->screencopy_frame_info.height, cast->framerate);
@@ -298,7 +298,7 @@ void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast) {
 	}
 	cast->pwr_stream_state = false;
 
-	enum spa_video_format format = xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format);
+	enum spa_video_format format = xdpw_format_pw_from_drm_fourcc(cast->screencopy_frame_info.format);
 
 	const struct spa_pod *param = build_format(&b, format,
 			cast->screencopy_frame_info.width, cast->screencopy_frame_info.height, cast->framerate);

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -182,6 +182,13 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 		data_type = 1<<SPA_DATA_MemFd;
 	}
 
+	logprint(DEBUG, "pipewire: Format negotiated:");
+	logprint(DEBUG, "pipewire: buffer_type: %u (%u)", cast->buffer_type, data_type);
+	logprint(DEBUG, "pipewire: format: %u", cast->pwr_format.format);
+	logprint(DEBUG, "pipewire: modifier: %lu", cast->pwr_format.modifier);
+	logprint(DEBUG, "pipewire: size: (%u, %u)", cast->pwr_format.size.width, cast->pwr_format.size.height);
+	logprint(DEBUG, "pipewire: max_framerate: (%u / %u)", cast->pwr_format.max_framerate.num, cast->pwr_format.max_framerate.denom);
+
 	params[0] = build_buffer(&b, blocks, cast->screencopy_frame_info[cast->buffer_type].size,
 			cast->screencopy_frame_info[cast->buffer_type].stride, data_type);
 
@@ -197,7 +204,7 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	struct xdpw_screencast_instance *cast = data;
 	struct spa_data *d;
 
-	logprint(TRACE, "pipewire: add buffer event handle");
+	logprint(DEBUG, "pipewire: add buffer event handle");
 
 	d = buffer->buffer->datas;
 
@@ -244,7 +251,7 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer) {
 	struct xdpw_screencast_instance *cast = data;
 
-	logprint(TRACE, "pipewire: remove buffer event handle");
+	logprint(DEBUG, "pipewire: remove buffer event handle");
 
 	struct xdpw_buffer *xdpw_buffer = buffer->user_data;
 	if (xdpw_buffer) {
@@ -313,8 +320,11 @@ void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast) {
 
 	logprint(TRACE, "********************");
 	logprint(TRACE, "pipewire: fd %u", d[0].fd);
-	logprint(TRACE, "pipewire: size %d", d[0].maxsize);
+	logprint(TRACE, "pipewire: maxsize %d", d[0].maxsize);
+	logprint(TRACE, "pipewire: size %d", d[0].chunk->size);
 	logprint(TRACE, "pipewire: stride %d", d[0].chunk->stride);
+	logprint(TRACE, "pipewire: offset %d", d[0].chunk->offset);
+	logprint(TRACE, "pipewire: chunk flags %d", d[0].chunk->flags);
 	logprint(TRACE, "pipewire: width %d", cast->current_frame.xdpw_buffer->width);
 	logprint(TRACE, "pipewire: height %d", cast->current_frame.xdpw_buffer->height);
 	logprint(TRACE, "pipewire: y_invert %d", cast->current_frame.y_invert);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -112,6 +112,8 @@ bool setup_outputs(struct xdpw_screencast_context *ctx, struct xdpw_session *ses
 		return false;
 	}
 
+	// Disable screencast sharing to avoid sharing between dmabuf and shm capable clients
+	/*
 	struct xdpw_screencast_instance *cast, *tmp_c;
 	wl_list_for_each_reverse_safe(cast, tmp_c, &ctx->screencast_instances, link) {
 		logprint(INFO, "xdpw: existing screencast instance: %d %s cursor",
@@ -132,6 +134,7 @@ bool setup_outputs(struct xdpw_screencast_context *ctx, struct xdpw_session *ses
 				cast, cast->refcount);
 		}
 	}
+	*/
 
 	if (!sess->screencast_instance) {
 		sess->screencast_instance = calloc(1, sizeof(struct xdpw_screencast_instance));

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -455,7 +455,7 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 		"streams", "a(ua{sv})", 1,
 		cast->node_id, 2,
 		"position", "(ii)", 0, 0,
-		"size", "(ii)", cast->screencopy_frame_info.width, cast->screencopy_frame_info.height);
+		"size", "(ii)", cast->screencopy_frame_info[WL_SHM].width, cast->screencopy_frame_info[WL_SHM].height);
 
 	if (ret < 0) {
 		return ret;

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -1,3 +1,4 @@
+#include "xdpw.h"
 #include "screencast_common.h"
 #include <assert.h>
 #include <fcntl.h>
@@ -135,10 +136,14 @@ struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 			return NULL;
 		}
 		break;
-	case DMABUF:
-		buffer->bo = gbm_bo_create(cast->ctx->gbm,
-				frame_info->width, frame_info->height, frame_info->format,
-				GBM_BO_USE_RENDERING);
+	case DMABUF:;
+		uint32_t flags = GBM_BO_USE_RENDERING;
+		if (cast->ctx->state->config->screencast_conf.force_mod_linear) {
+			flags |= GBM_BO_USE_LINEAR;
+		}
+
+		buffer->bo = gbm_bo_create(cast->ctx->gbm, frame_info->width, frame_info->height,
+				frame_info->format, flags);
 		if (buffer->bo == NULL) {
 			logprint(ERROR, "xdpw: failed to create gbm_bo");
 			free(buffer);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -91,7 +91,7 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 	cast->screencopy_frame_info.height = height;
 	cast->screencopy_frame_info.stride = stride;
 	cast->screencopy_frame_info.size = stride * height;
-	cast->screencopy_frame_info.format = format;
+	cast->screencopy_frame_info.format = xdpw_format_drm_fourcc_from_wl_shm(format);
 
 	if (zwlr_screencopy_manager_v1_get_version(cast->ctx->screencopy_manager) < 3) {
 		wlr_frame_buffer_done(cast, frame);
@@ -116,8 +116,8 @@ static void wlr_frame_buffer_done(void *data,
 	}
 
 	// Check if announced screencopy information is compatible with pipewire meta
-	if ((cast->pwr_format.format != xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format) &&
-			cast->pwr_format.format != xdpw_format_pw_strip_alpha(xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format))) ||
+	if ((cast->pwr_format.format != xdpw_format_pw_from_drm_fourcc(cast->screencopy_frame_info.format) &&
+			cast->pwr_format.format != xdpw_format_pw_strip_alpha(xdpw_format_pw_from_drm_fourcc(cast->screencopy_frame_info.format))) ||
 			cast->pwr_format.size.width != cast->screencopy_frame_info.width ||
 			cast->pwr_format.size.height != cast->screencopy_frame_info.height) {
 		logprint(DEBUG, "wlroots: pipewire and wlroots metadata are incompatible. Renegotiate stream");

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -1,5 +1,6 @@
 #include "wlr_screencast.h"
 
+#include "linux-dmabuf-unstable-v1-client-protocol.h"
 #include "wlr-screencopy-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
 #include <fcntl.h>
@@ -582,6 +583,10 @@ static void wlr_registry_handle_add(void *data, struct wl_registry *reg,
 		ctx->xdg_output_manager =
 			wl_registry_bind(reg, id, &zxdg_output_manager_v1_interface, XDG_OUTPUT_MANAGER_VERSION);
 	}
+	if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
+		logprint(DEBUG, "wlroots: |-- registered to interface %s (Version %u)", interface, LINUX_DMABUF_VERSION);
+		ctx->linux_dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, LINUX_DMABUF_VERSION);
+	}
 }
 
 static void wlr_registry_handle_remove(void *data, struct wl_registry *reg,
@@ -676,6 +681,9 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 		int fd = gbm_device_get_fd(ctx->gbm);
 		gbm_device_destroy(ctx->gbm);
 		close(fd);
+	}
+	if (ctx->linux_dmabuf) {
+		zwp_linux_dmabuf_v1_destroy(ctx->linux_dmabuf);
 	}
 	if (ctx->registry) {
 		wl_registry_destroy(ctx->registry);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -641,6 +641,12 @@ int xdpw_wlr_screencopy_init(struct xdpw_state *state) {
 		return -1;
 	}
 
+	// make sure we have a gbm device
+	ctx->gbm = xdpw_gbm_device_create();
+	if (!ctx->gbm) {
+		logprint(ERROR, "System doesn't support gbm!");
+	}
+
 	return 0;
 }
 
@@ -665,6 +671,11 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 	}
 	if (ctx->xdg_output_manager) {
 		zxdg_output_manager_v1_destroy(ctx->xdg_output_manager);
+	}
+	if (ctx->gbm) {
+		int fd = gbm_device_get_fd(ctx->gbm);
+		gbm_device_destroy(ctx->gbm);
+		close(fd);
 	}
 	if (ctx->registry) {
 		wl_registry_destroy(ctx->registry);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -101,7 +101,13 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 static void wlr_frame_linux_dmabuf(void *data,
 		struct zwlr_screencopy_frame_v1 *frame,
 		uint32_t format, uint32_t width, uint32_t height) {
+	struct xdpw_screencast_instance *cast = data;
+
 	logprint(TRACE, "wlroots: linux_dmabuf event handler");
+
+	cast->screencopy_frame_info[DMABUF].width = width;
+	cast->screencopy_frame_info[DMABUF].height = height;
+	cast->screencopy_frame_info[DMABUF].format = format;
 }
 
 static void wlr_frame_buffer_done(void *data,

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -71,6 +71,15 @@ These options need to be placed under the **[screencast]** section.
 	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
 	  see **OUTPUT CHOOSER**.
 
+**force_mod_linear** = _bool_
+	Force buffers with implicit modifiers to be linear (experimental)
+
+	Setting this option to 1 will force xdpw to allocate dma-bufs with implicit modifier as linear.
+	This option shouldn't be required on single gpu setups, but can increase compatibility
+	especially on setups with multiple gpus.
+
+	This option is experimental and can be removed or replaced in future versions.
+
 ## OUTPUT CHOOSER
 
 The chooser can be any program or script with the following behaviour:


### PR DESCRIPTION
Splits the part containing the modifierless codepaths for dmabuf screensharing from #152 

Depends: #141 
Depends: #184 