### PR TITLE
Add support for 10-bit colour formats

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ add_project_arguments('-DSYSCONFDIR="@0@"'.format(join_paths(prefix, sysconfdir)
 inc = include_directories('include')
 
 rt = cc.find_library('rt')
-pipewire = dependency('libpipewire-0.3', version: '>= 0.3.34')
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.41')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 iniparser = dependency('inih')

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -6,6 +6,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "logger.h"
+
 void randname(char *buf) {
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
@@ -73,7 +75,25 @@ enum spa_video_format xdpw_format_pw_from_wl_shm(enum wl_shm_format format) {
 		return SPA_VIDEO_FORMAT_xRGB;
 	case WL_SHM_FORMAT_NV12:
 		return SPA_VIDEO_FORMAT_NV12;
+	case WL_SHM_FORMAT_XRGB2101010:
+		return SPA_VIDEO_FORMAT_xRGB_210LE;
+	case WL_SHM_FORMAT_XBGR2101010:
+		return SPA_VIDEO_FORMAT_xBGR_210LE;
+	case WL_SHM_FORMAT_RGBX1010102:
+		return SPA_VIDEO_FORMAT_RGBx_102LE;
+	case WL_SHM_FORMAT_BGRX1010102:
+		return SPA_VIDEO_FORMAT_BGRx_102LE;
+	case WL_SHM_FORMAT_ARGB2101010:
+		return SPA_VIDEO_FORMAT_ARGB_210LE;
+	case WL_SHM_FORMAT_ABGR2101010:
+		return SPA_VIDEO_FORMAT_ABGR_210LE;
+	case WL_SHM_FORMAT_RGBA1010102:
+		return SPA_VIDEO_FORMAT_RGBA_102LE;
+	case WL_SHM_FORMAT_BGRA1010102:
+		return SPA_VIDEO_FORMAT_BGRA_102LE;
 	default:
+		logprint(ERROR, "xdg-desktop-portal-wlr: failed to convert wl_shm "
+			"format 0x%08x to spa_video_format", format);
 		abort();
 	}
 }


### PR DESCRIPTION
This makes PipeWire 0.3.41 the minimum required version, as the colour formats were introduced in that version.