### PR TITLE
screencast: remove check on loop_iterate

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -432,8 +432,9 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 
 	while (cast->node_id == SPA_ID_INVALID) {
 		int ret = pw_loop_iterate(state->pw_loop, 0);
-		if (ret != 0) {
+		if (ret < 0) {
 			logprint(ERROR, "pipewire_loop_iterate failed: %s", spa_strerror(ret));
+			return ret;
 		}
 	}
 


### PR DESCRIPTION
According to the documentation [1] pw_loop_iterate (a macro for
spa_loop_control_iterate) will return the number of dispatched fd's
which don't have any value for error handling.

[1] https://docs.pipewire.org/group__spa__loop.html#ga3bae0b32100f5752b3372a505c8e04f6