### PR TITLE
screencast: unmess the pipewire/wlr split

### DIFF
--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -3,11 +3,13 @@
 
 #include "screencast_common.h"
 
-#define XDPW_PWR_BUFFERS 4
+#define XDPW_PWR_BUFFERS 2
+#define XDPW_PWR_BUFFERS_MIN 2
 #define XDPW_PWR_ALIGN 16
 
 void xdpw_pwr_dequeue_buffer(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast);
+void xdpw_pwr_swap_buffer(struct xdpw_screencast_instance *cast);
 void pwr_update_stream_param(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_stream_create(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_stream_destroy(struct xdpw_screencast_instance *cast);

--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -6,8 +6,6 @@
 #define XDPW_PWR_BUFFERS 4
 #define XDPW_PWR_ALIGN 16
 
-void xdpw_pwr_trigger_process(struct xdpw_screencast_instance *cast);
-bool xdpw_pwr_is_driving(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_dequeue_buffer(struct xdpw_screencast_instance *cast);
 void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast);
 void pwr_update_stream_param(struct xdpw_screencast_instance *cast);

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -31,6 +31,7 @@ enum xdpw_chooser_types {
 
 enum xdpw_frame_state {
   XDPW_FRAME_STATE_NONE,
+  XDPW_FRAME_STATE_STARTED,
   XDPW_FRAME_STATE_RENEG,
   XDPW_FRAME_STATE_FAILED,
   XDPW_FRAME_STATE_SUCCESS,

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -50,13 +50,11 @@ struct xdpw_frame_damage {
 };
 
 struct xdpw_frame {
-	uint32_t size;
-	uint32_t stride;
 	bool y_invert;
 	uint64_t tv_sec;
 	uint32_t tv_nsec;
 	struct xdpw_frame_damage damage;
-	struct wl_buffer *buffer;
+	struct xdpw_buffer *xdpw_buffer;
 	struct pw_buffer *current_pw_buffer;
 };
 
@@ -66,6 +64,21 @@ struct xdpw_screencopy_frame_info {
 	uint32_t size;
 	uint32_t stride;
 	enum wl_shm_format format;
+};
+
+struct xdpw_buffer {
+	struct wl_list link;
+
+	uint32_t width;
+	uint32_t height;
+	enum wl_shm_format format;
+
+	int fd;
+	uint32_t size;
+	uint32_t stride;
+	uint32_t offset;
+
+	struct wl_buffer *buffer;
 };
 
 struct xdpw_screencast_context {
@@ -98,6 +111,7 @@ struct xdpw_screencast_instance {
 	bool initialized;
 	struct xdpw_frame current_frame;
 	enum xdpw_frame_state frame_state;
+	struct wl_list buffer_list;
 
 	// pipewire
 	struct pw_stream *stream;
@@ -136,9 +150,9 @@ struct xdpw_wlr_output {
 };
 
 void randname(char *buf);
-int anonymous_shm_open(void);
-struct wl_buffer *import_wl_shm_buffer(struct xdpw_screencast_instance *cast, int fd,
-	enum wl_shm_format fmt, int width, int height, int stride);
+struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
+	struct xdpw_screencopy_frame_info *frame_info);
+void xdpw_buffer_destroy(struct xdpw_buffer *buffer);
 enum spa_video_format xdpw_format_pw_from_wl_shm(enum wl_shm_format format);
 enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format);
 

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -131,6 +131,7 @@ struct xdpw_screencast_instance {
 	bool with_cursor;
 	int err;
 	bool quit;
+	bool need_buffer;
 
 	// fps limit
 	struct fps_limit_state fps_limit;

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -60,7 +60,7 @@ struct xdpw_frame {
 	struct pw_buffer *current_pw_buffer;
 };
 
-struct xdpw_screencopy_frame {
+struct xdpw_screencopy_frame_info {
 	uint32_t width;
 	uint32_t height;
 	uint32_t size;
@@ -113,7 +113,7 @@ struct xdpw_screencast_instance {
 	struct xdpw_wlr_output *target_output;
 	uint32_t max_framerate;
 	struct zwlr_screencopy_frame_v1 *wlr_frame;
-	struct xdpw_screencopy_frame screencopy_frame;
+	struct xdpw_screencopy_frame_info screencopy_frame_info;
 	bool with_cursor;
 	int err;
 	bool quit;

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -55,7 +55,7 @@ struct xdpw_frame {
 	uint32_t tv_nsec;
 	struct xdpw_frame_damage damage;
 	struct xdpw_buffer *xdpw_buffer;
-	struct pw_buffer *current_pw_buffer;
+	struct pw_buffer *pw_buffer;
 };
 
 struct xdpw_screencopy_frame_info {

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -68,7 +68,13 @@ void xdpw_session_destroy(struct xdpw_session *sess) {
 		logprint(DEBUG, "xdpw: screencast instance %p now has %d references",
 			cast, cast->refcount);
 		if (cast->refcount < 1) {
-			cast->quit = true;
+			if (cast->frame_state == XDPW_FRAME_STATE_NONE) {
+				logprint(TRACE, "xdpw: screencast instance not streaming, destroy it");
+				xdpw_screencast_instance_destroy(cast);
+			} else {
+				logprint(TRACE, "xdpw: screencast instance still streaming, set quit flag");
+				cast->quit = true;
+			}
 		}
 	}
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -44,14 +44,6 @@ static struct spa_pod *build_format(struct spa_pod_builder *b, enum spa_video_fo
 	return spa_pod_builder_pop(b, &f[0]);
 }
 
-static void pwr_handle_stream_process(void *data) {
-	struct xdpw_screencast_instance *cast = data;
-
-	logprint(TRACE, "pipewire: stream process");
-
-	xdpw_wlr_frame_start(cast);
-}
-
 static void pwr_handle_stream_state_changed(void *data,
 		enum pw_stream_state old, enum pw_stream_state state, const char *error) {
 	struct xdpw_screencast_instance *cast = data;
@@ -64,7 +56,7 @@ static void pwr_handle_stream_state_changed(void *data,
 	switch (state) {
 	case PW_STREAM_STATE_STREAMING:
 		cast->pwr_stream_state = true;
-		if (!cast->wlr_frame) {
+		if (cast->frame_state == XDPW_FRAME_STATE_NONE) {
 			xdpw_wlr_frame_start(cast);
 		}
 		break;
@@ -184,16 +176,7 @@ static const struct pw_stream_events pwr_stream_events = {
 	.param_changed = pwr_handle_stream_param_changed,
 	.add_buffer = pwr_handle_stream_add_buffer,
 	.remove_buffer = pwr_handle_stream_remove_buffer,
-	.process = pwr_handle_stream_process,
 };
-
-void xdpw_pwr_trigger_process(struct xdpw_screencast_instance *cast) {
-	pw_stream_trigger_process(cast->stream);
-}
-
-bool xdpw_pwr_is_driving(struct xdpw_screencast_instance *cast) {
-	return pw_stream_is_driving(cast->stream);
-}
 
 void xdpw_pwr_dequeue_buffer(struct xdpw_screencast_instance *cast) {
 	logprint(TRACE, "pipewire: dequeueing buffer");

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -449,7 +449,7 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 		"streams", "a(ua{sv})", 1,
 		cast->node_id, 2,
 		"position", "(ii)", 0, 0,
-		"size", "(ii)", cast->screencopy_frame.width, cast->screencopy_frame.height);
+		"size", "(ii)", cast->screencopy_frame_info.width, cast->screencopy_frame_info.height);
 
 	if (ret < 0) {
 		return ret;

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -70,6 +70,7 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 	cast->with_cursor = with_cursor;
 	cast->refcount = 1;
 	cast->node_id = SPA_ID_INVALID;
+	cast->need_buffer = false;
 	wl_list_init(&cast->buffer_list);
 	logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);
 	wl_list_insert(&ctx->screencast_instances, &cast->link);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -70,6 +70,7 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 	cast->with_cursor = with_cursor;
 	cast->refcount = 1;
 	cast->node_id = SPA_ID_INVALID;
+	wl_list_init(&cast->buffer_list);
 	logprint(INFO, "xdpw: screencast instance %p has %d references", cast, cast->refcount);
 	wl_list_insert(&ctx->screencast_instances, &cast->link);
 	logprint(INFO, "xdpw: %d active screencast instances",
@@ -91,6 +92,7 @@ void xdpw_screencast_instance_destroy(struct xdpw_screencast_instance *cast) {
 
 	wl_list_remove(&cast->link);
 	xdpw_pwr_stream_destroy(cast);
+	assert(wl_list_length(&cast->buffer_list) == 0);
 	free(cast);
 }
 

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -134,18 +134,18 @@ static void wlr_frame_buffer_done(void *data,
 		return;
 	}
 
+	assert(cast->current_frame.xdpw_buffer);
+
 	// Check if dequeued buffer is compatible with announced buffer
-	if (cast->current_frame.size != cast->screencopy_frame_info.size ||
-			cast->current_frame.stride != cast->screencopy_frame_info.stride) {
+	if (cast->current_frame.xdpw_buffer->size != cast->screencopy_frame_info.size ||
+			cast->current_frame.xdpw_buffer->stride != cast->screencopy_frame_info.stride) {
 		logprint(DEBUG, "wlroots: pipewire buffer has wrong dimensions");
 		cast->frame_state = XDPW_FRAME_STATE_FAILED;
 		xdpw_wlr_frame_finish(cast);
 		return;
 	}
 
-	assert(cast->current_frame.buffer);
-
-	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->current_frame.buffer);
+	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->current_frame.xdpw_buffer->buffer);
 	logprint(TRACE, "wlroots: frame copied");
 
 	fps_limit_measure_start(&cast->fps_limit, cast->framerate);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -130,6 +130,7 @@ static void wlr_frame_buffer_done(void *data,
 		xdpw_pwr_dequeue_buffer(cast);
 	}
 
+	cast->need_buffer = false;
 	if (!cast->current_frame.xdpw_buffer) {
 		logprint(WARN, "wlroots: no current buffer");
 		xdpw_wlr_frame_finish(cast);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -32,7 +32,11 @@ void xdpw_wlr_frame_finish(struct xdpw_screencast_instance *cast) {
 
 	wlr_frame_free(cast);
 
-	if (!cast->pwr_stream_state) {
+	if (cast->quit || cast->err) {
+		// TODO: revisit the exit condition (remove quit?)
+		// and clean up sessions that still exist if err
+		// is the cause of the instance_destroy call
+		xdpw_screencast_instance_destroy(cast);
 		return;
 	}
 
@@ -41,31 +45,24 @@ void xdpw_wlr_frame_finish(struct xdpw_screencast_instance *cast) {
 		xdpw_pwr_enqueue_buffer(cast);
 	}
 
+	if (!cast->pwr_stream_state) {
+		cast->frame_state = XDPW_FRAME_STATE_NONE;
+		return;
+	}
+
 	if (cast->frame_state == XDPW_FRAME_STATE_RENEG) {
 		pwr_update_stream_param(cast);
 	}
 
-	if (cast->quit || cast->err) {
-		// TODO: revisit the exit condition (remove quit?)
-		// and clean up sessions that still exist if err
-		// is the cause of the instance_destroy call
-		xdpw_screencast_instance_destroy(cast);
-		return ;
-	}
-
-	if (cast->pwr_stream_state && xdpw_pwr_is_driving(cast)) {
-		if (cast->frame_state == XDPW_FRAME_STATE_SUCCESS) {
-			uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
-			if (delay_ns > 0) {
-				xdpw_add_timer(cast->ctx->state, delay_ns,
-					(xdpw_event_loop_timer_func_t) xdpw_pwr_trigger_process, cast);
-			} else {
-				xdpw_pwr_trigger_process(cast);
-			}
-		} else {
-			xdpw_pwr_trigger_process(cast);
+	if (cast->frame_state == XDPW_FRAME_STATE_SUCCESS) {
+		uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
+		if (delay_ns > 0) {
+			xdpw_add_timer(cast->ctx->state, delay_ns,
+				(xdpw_event_loop_timer_func_t) xdpw_wlr_frame_start, cast);
+			return;
 		}
 	}
+	xdpw_wlr_frame_start(cast);
 }
 
 void xdpw_wlr_frame_start(struct xdpw_screencast_instance *cast) {
@@ -73,7 +70,7 @@ void xdpw_wlr_frame_start(struct xdpw_screencast_instance *cast) {
 	if (cast->err) {
 		logprint(ERROR, "wlroots: nonrecoverable error has happened. shutting down instance");
 		xdpw_screencast_instance_destroy(cast);
-		return ;
+		return;
 	}
 
 	if (cast->pwr_stream_state) {
@@ -81,11 +78,10 @@ void xdpw_wlr_frame_start(struct xdpw_screencast_instance *cast) {
 
 		if (!cast->current_frame.current_pw_buffer) {
 			logprint(WARN, "wlroots: failed to dequeue buffer");
-			// TODO: wait for next frame
 		}
 	}
 
-	cast->frame_state = XDPW_FRAME_STATE_NONE;
+	cast->frame_state = XDPW_FRAME_STATE_STARTED;
 	xdpw_wlr_register_cb(cast);
 }
 
@@ -121,11 +117,6 @@ static void wlr_frame_buffer_done(void *data,
 	struct xdpw_screencast_instance *cast = data;
 
 	logprint(TRACE, "wlroots: buffer_done event handler");
-	if (!cast->pwr_stream_state) {
-		xdpw_wlr_frame_finish(cast);
-		return;
-	}
-
 	if (!cast->current_frame.current_pw_buffer) {
 		logprint(WARN, "wlroots: no current buffer");
 		xdpw_wlr_frame_finish(cast);

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -95,11 +95,11 @@ static void wlr_frame_buffer(void *data, struct zwlr_screencopy_frame_v1 *frame,
 	logprint(TRACE, "wlroots: buffer event handler");
 	cast->wlr_frame = frame;
 
-	cast->screencopy_frame.width = width;
-	cast->screencopy_frame.height = height;
-	cast->screencopy_frame.stride = stride;
-	cast->screencopy_frame.size = stride * height;
-	cast->screencopy_frame.format = format;
+	cast->screencopy_frame_info.width = width;
+	cast->screencopy_frame_info.height = height;
+	cast->screencopy_frame_info.stride = stride;
+	cast->screencopy_frame_info.size = stride * height;
+	cast->screencopy_frame_info.format = format;
 
 	if (zwlr_screencopy_manager_v1_get_version(cast->ctx->screencopy_manager) < 3) {
 		wlr_frame_buffer_done(cast, frame);
@@ -124,10 +124,10 @@ static void wlr_frame_buffer_done(void *data,
 	}
 
 	// Check if announced screencopy information is compatible with pipewire meta
-	if ((cast->pwr_format.format != xdpw_format_pw_from_wl_shm(cast->screencopy_frame.format) &&
-			cast->pwr_format.format != xdpw_format_pw_strip_alpha(xdpw_format_pw_from_wl_shm(cast->screencopy_frame.format))) ||
-			cast->pwr_format.size.width != cast->screencopy_frame.width ||
-			cast->pwr_format.size.height != cast->screencopy_frame.height) {
+	if ((cast->pwr_format.format != xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format) &&
+			cast->pwr_format.format != xdpw_format_pw_strip_alpha(xdpw_format_pw_from_wl_shm(cast->screencopy_frame_info.format))) ||
+			cast->pwr_format.size.width != cast->screencopy_frame_info.width ||
+			cast->pwr_format.size.height != cast->screencopy_frame_info.height) {
 		logprint(DEBUG, "wlroots: pipewire and wlroots metadata are incompatible. Renegotiate stream");
 		cast->frame_state = XDPW_FRAME_STATE_RENEG;
 		xdpw_wlr_frame_finish(cast);
@@ -135,8 +135,8 @@ static void wlr_frame_buffer_done(void *data,
 	}
 
 	// Check if dequeued buffer is compatible with announced buffer
-	if (cast->current_frame.size != cast->screencopy_frame.size ||
-			cast->current_frame.stride != cast->screencopy_frame.stride) {
+	if (cast->current_frame.size != cast->screencopy_frame_info.size ||
+			cast->current_frame.stride != cast->screencopy_frame_info.stride) {
 		logprint(DEBUG, "wlroots: pipewire buffer has wrong dimensions");
 		cast->frame_state = XDPW_FRAME_STATE_FAILED;
 		xdpw_wlr_frame_finish(cast);


### PR DESCRIPTION
Using the on_process event of the PipeWire can create a race condition
when a previous started screencast hasn't finished before the next
event.

This MR is composed of following parts:
* nuke the racy on_process part
* cleanup some stuff
* intruduce xdpw_buffers 
* decouple the actual buffer (xdpw_buffer) from the pw_buffer carrier and swap the buffer from the PipeWire queue after each copy.
* Relax the swap incase the PipeWire queue is lagging behind.

Resolves: #182 