### PR TITLE
screencast: remove xdg-output protocol

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -116,7 +116,6 @@ struct xdpw_screencast_context {
 	struct wl_list output_list;
 	struct wl_registry *registry;
 	struct zwlr_screencopy_manager_v1 *screencopy_manager;
-	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_shm *shm;
 	struct zwp_linux_dmabuf_v1 *linux_dmabuf;
 	struct zwp_linux_dmabuf_feedback_v1 *linux_dmabuf_feedback;
@@ -172,7 +171,6 @@ struct xdpw_wlr_output {
 	struct wl_list link;
 	uint32_t id;
 	struct wl_output *output;
-	struct zxdg_output_v1 *xdg_output;
 	char *make;
 	char *model;
 	char *name;

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -3,14 +3,12 @@
 
 #include "screencast_common.h"
 
-#define WL_OUTPUT_VERSION 1
+#define WL_OUTPUT_VERSION 4
 
 #define SC_MANAGER_VERSION 3
 #define SC_MANAGER_VERSION_MIN 2
 
 #define WL_SHM_VERSION 1
-
-#define XDG_OUTPUT_MANAGER_VERSION 3
 
 #define LINUX_DMABUF_VERSION 4
 #define LINUX_DMABUF_VERSION_MIN 3


### PR DESCRIPTION
Since version 4 wl_output announces a name for the output. This removes
the need to retrieve this information from the xdg-output protocol.