### PR TITLE
Add phosh to portal's UseIn list

### DIFF
--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
 Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=wlroots;sway;Wayfire;river
+UseIn=wlroots;sway;Wayfire;river;phosh;


### PR DESCRIPTION
The compositor is phoc but XDG_CURRENT_DESKTOP has "Phosh".