### PR TITLE
build: define _GNU_SOURCE for PipeWire 0.3.49

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,12 @@ if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
 	epoll = dependency('epoll-shim')
 endif
 
+if pipewire.version() == '0.3.49'
+        add_project_arguments(cc.get_supported_arguments([
+                '-D_GNU_SOURCE',
+        ]), language: 'c')
+endif
+
 if get_option('sd-bus-provider') == 'auto'
 	assert(get_option('auto_features').auto(), 'sd-bus-provider must not be set to auto since auto_features != auto')
 	sdbus = dependency('libsystemd',


### PR DESCRIPTION
PipeWire 0.3.49 added locale aware string functions to the spa library,
which are only available defining _GNU_SOURCE [1]. This will be fixed in
the next PipeWire release [2]

[1] https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/5f4d031db0a5515936b4d1943110e7cc87c30059
[2] https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1206/