### PR TITLE
Improve Interoperability between APIs using explicit and implicit modifiers

### DIFF
--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -241,6 +241,9 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 					flags = cast->ctx->state->config->screencast_conf.force_mod_linear ?
 						GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR : GBM_BO_USE_RENDERING;
 					break;
+				case DRM_FORMAT_MOD_LINEAR:
+					flags = GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR;
+					break;
 				default:
 					continue;
 				}

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -153,6 +153,12 @@ struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 				frame_info->format, flags);
 		}
 
+		// Fallback for linear buffers via the implicit api
+		if (buffer->bo == NULL && cast->pwr_format.modifier == DRM_FORMAT_MOD_LINEAR) {
+			buffer->bo = gbm_bo_create(cast->ctx->gbm, frame_info->width, frame_info->height,
+					frame_info->format, flags | GBM_BO_USE_LINEAR);
+		}
+
 		if (buffer->bo == NULL) {
 			logprint(ERROR, "xdpw: failed to create gbm_bo");
 			free(buffer);


### PR DESCRIPTION
When having to share buffers between modifier aware APIs and modifier unaware APIs the common denominator is to create a buffer with linear layout. This MR announces support for a linear modifier when the compositor only supports implicit modifiers using the `GBM_BO_USE_LINEAR` flag to create a buffer with linear layout.