### PR TITLE
Add `jay` to wlr.portal UseIn list

### DIFF
--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
 Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=wlroots;sway;Wayfire;river
+UseIn=wlroots;sway;Wayfire;river;jay


### PR DESCRIPTION
Jay [1] is a new wayland compositor that is not based on wlroots and
does not support all wlroots extensions. Therefore it would not be
appropriate to add wlroots to its XDG_CURRENT_DESKTOP list. It does
however implement all wlroots extensions necessary to run
xdg-desktop-portal-wlr.

[1] https://github.com/mahkoh/jay