### PR TITLE
Draft: Json chooser v2: A complex chooser to handle options

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -10,6 +10,7 @@ packages:
   - scdoc
   - libdrm
   - mesa-dev
+  - json-c-dev
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -9,6 +9,7 @@ packages:
   - libinih
   - scdoc
   - mesa
+  - json-c
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -11,6 +11,7 @@ packages:
   - scdoc
   - graphics/libdrm
   - graphics/mesa-libs
+  - json-c
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/chooser-protocol.json
+++ b/chooser-protocol.json
@@ -1,0 +1,53 @@
+{
+  "request": {
+    "version": 1,
+    "revision": 0,
+    "monitors": [
+      {
+        "name": "Name1",
+        "make": "Make1",
+        "model": "Model1",
+        "id": 1
+      },
+      {
+        "name": "Name2",
+        "make": "Make2",
+        "model": "Model2",
+        "id": 2
+      }
+    ],
+    "windows": [
+      {
+        "title": "Title1",
+        "app_id": "App_Id1",
+        "id": 1
+      },
+      {
+        "title": "Title2",
+        "app_id": "App_Id2",
+        "id": 2
+      }
+    ],
+    "options": {
+      "persist_mode": [
+		  {"none": 0},
+		  {"transient": 1},
+		  {"permanent": 2}
+	  ]
+    }
+  },
+  "response": {
+    "version": 1,
+    "revision": 0,
+    "target_type": "output",
+    "target": {
+      "name": "Name1",
+      "make": "Make1",
+      "model": "Model1",
+      "id": 1
+    },
+    "options": {
+      "persist_mode": 0
+    }
+  }
+}

--- a/contrib/dmenu-chooser-json.sh
+++ b/contrib/dmenu-chooser-json.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+chooser=$1
+
+read -r json
+echo "$json" >&2
+output=$(echo $json | jq  '.monitors | .[] | (.id|tostring) + ":" + .name + ":" + .make + ":" + .model' | tr -d '"' | ${chooser:="wofi -d"})
+ret=$!
+version=$(echo $json | jq '.version|tostring')
+revision=$(echo $json | jq '.revision|tostring')
+target_type=monitor
+IFS=":" read -r id name make model <<<"$output"
+echo "version:$version" >&2
+echo "revision:$revision" >&2
+echo "target_type:$target_type" >&2
+echo "name:$name" >&2
+echo "model:$model" >&2
+echo "make:$make" >&2
+echo "id $id" >&2
+
+jq -c --null-input \
+  --argjson version $version \
+  --argjson revision $revision \
+  --arg target_type "$target_type" \
+  --arg name "$name" \
+  --arg model "$model" \
+  --arg make "$make" \
+  --argjson id $id \
+  '{"version": $version, "revision": $revision, "target_type": $target_type, "target": { "name": $name, "model": $model, "make": $make, "id": $id }}'
+exit $ret

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -41,6 +41,7 @@ enum xdpw_chooser_types {
   XDPW_CHOOSER_NONE,
   XDPW_CHOOSER_SIMPLE,
   XDPW_CHOOSER_DMENU,
+  XDPW_CHOOSER_JSON,
 };
 
 enum xdpw_frame_state {
@@ -54,6 +55,17 @@ enum xdpw_frame_state {
 struct xdpw_output_chooser {
 	enum xdpw_chooser_types type;
 	char *cmd;
+};
+
+struct xdpw_chooser_opts {
+	struct wl_list *output_list;
+
+	// XDPW_CHOOSER_JSON
+	uint32_t target_mask;
+	enum persist_modes persist_mode;
+
+	// XDPW_CHOOSER_NONE
+	char *outputname;
 };
 
 struct xdpw_frame_damage {

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -18,7 +18,8 @@ struct xdpw_state;
 int xdpw_wlr_screencopy_init(struct xdpw_state *state);
 void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx);
 
-bool xdpw_wlr_target_chooser(struct xdpw_screencast_context *ctx, struct xdpw_screencast_target *target);
+bool xdpw_wlr_target_chooser(struct xdpw_output_chooser *chooser, struct xdpw_chooser_opts *opts,
+		struct xdpw_screencast_target *target);
 bool xdpw_wlr_target_from_data(struct xdpw_screencast_context *ctx, struct xdpw_screencast_target *target,
 		struct xdpw_screencast_restore_data *data);
 

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.24')
 iniparser = dependency('inih')
 gbm = dependency('gbm')
 drm = dependency('libdrm')
+jsonc = dependency('json-c')
 
 epoll = dependency('', required: false)
 if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
@@ -90,6 +91,7 @@ executable(
 		iniparser,
 		gbm,
 		drm,
+		jsonc,
 		epoll,
 	],
 	include_directories: [inc],

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -127,23 +127,17 @@ bool setup_target(struct xdpw_screencast_context *ctx, struct xdpw_session *sess
 		target_initialized = xdpw_wlr_target_from_data(ctx, target, data);
 	}
 	if (!target_initialized) {
-		target_initialized = xdpw_wlr_target_chooser(ctx, target);
-		//TODO: Chooser option to confirm the persist mode
-		const char *env_persist_str = getenv("XDPW_PERSIST_MODE");
-		if (env_persist_str) {
-			if (strcmp(env_persist_str, "transient") == 0) {
-				sess->screencast_data.persist_mode = sess->screencast_data.persist_mode > PERSIST_TRANSIENT
-					? PERSIST_TRANSIENT : sess->screencast_data.persist_mode;
-			} else if (strcmp(env_persist_str, "permanent") == 0) {
-				sess->screencast_data.persist_mode = sess->screencast_data.persist_mode > PERSIST_PERMANENT
-					? PERSIST_PERMANENT : sess->screencast_data.persist_mode;
-			} else {
-				sess->screencast_data.persist_mode = PERSIST_NONE;
-			}
-
-		} else {
-			sess->screencast_data.persist_mode = PERSIST_NONE;
-		}
+		struct xdpw_output_chooser chooser = {
+			.cmd = ctx->state->config->screencast_conf.chooser_cmd,
+			.type = ctx->state->config->screencast_conf.chooser_type,
+		};
+		struct xdpw_chooser_opts chooser_opts = {
+			.output_list = &ctx->output_list,
+			.target_mask = (1<<MONITOR),
+			.persist_mode = sess->screencast_data.persist_mode,
+			.outputname = ctx->state->config->screencast_conf.output_name,
+		};
+		target_initialized = xdpw_wlr_target_chooser(&chooser, &chooser_opts, target);
 	}
 	if (!target_initialized) {
 		logprint(ERROR, "wlroots: no output found");

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -391,6 +391,8 @@ enum xdpw_chooser_types get_chooser_type(const char *chooser_type) {
 		return XDPW_CHOOSER_SIMPLE;
 	} else if (strcmp(chooser_type, "dmenu") == 0) {
 		return XDPW_CHOOSER_DMENU;
+	} else if (strcmp(chooser_type, "json") == 0) {
+		return XDPW_CHOOSER_JSON;
 	}
 	fprintf(stderr, "Could not understand chooser type %s\n", chooser_type);
 	exit(1);
@@ -406,6 +408,8 @@ const char *chooser_type_str(enum xdpw_chooser_types chooser_type) {
 		return "simple";
 	case XDPW_CHOOSER_DMENU:
 		return "dmenu";
+	case XDPW_CHOOSER_JSON:
+		return "json";
 	}
 	fprintf(stderr, "Could not find chooser type %d\n", chooser_type);
 	abort();

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -68,7 +68,7 @@ These options need to be placed under the **[screencast]** section.
 	  (slurp, wofi, bemenu) and will fallback to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
-	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
+	- simple, dmenu, json: xdpw will launch the chooser given by **chooser_cmd**. For more details
 	  see **OUTPUT CHOOSER**.
 
 **force_mod_linear** = _bool_
@@ -93,6 +93,8 @@ The chooser can be any program or script with the following behaviour:
 Supported types of choosers via the **chooser_type** option:
 - simple: the chooser is just called without anything further on stdin.
 - dmenu: the chooser receives a newline separated list (dmenu style) of outputs on stdin.
+- json: the chooser receives a list of outputs formated as a json stdin ++
+  {"monitor":[{"name": "eDP-1","make": "<manufacturer>","model": "<model>","id": "42"}]}
 
 # SEE ALSO
 


### PR DESCRIPTION
If we want to query the user for options like `persist_mode` we need to send more data than just the name of the output. We also need sth. more complex when window selection is possible. 

In any case this is a PoC sending the data encoded via json between chooser and xdpw in both directions. The scheme is versioned with `version (breaking)` and `revision (backwards compatible on the xdpw side)`. 

Note: man-page has still the scheme from #105 . The new scheme is demonstrated in `chooser-protocol.json`.

Windows got an additional arbitrary id, since two toplevels can have the same `app_id` and `title`.

Supersedes: #105 

CC: @emersion 