### PR TITLE
Restore session transient

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -11,7 +11,8 @@
 
 // this seems to be right based on
 // https://github.com/flatpak/xdg-desktop-portal/blob/309a1fc0cf2fb32cceb91dbc666d20cf0a3202c2/src/screen-cast.c#L955
-#define XDP_CAST_PROTO_VER 3
+#define XDP_CAST_PROTO_VER 4
+#define XDP_CAST_DATA_VER 1
 
 enum cursor_modes {
   HIDDEN = 1,
@@ -168,6 +169,14 @@ struct xdpw_screencast_instance {
 	struct fps_limit_state fps_limit;
 };
 
+struct xdpw_screencast_session_data {
+	uint32_t version;
+	struct xdpw_screencast_instance *screencast_instance;
+	char *output_name;
+	uint32_t cursor_mode;
+	uint32_t persist_mode;
+};
+
 struct xdpw_wlr_output {
 	struct wl_list link;
 	uint32_t id;
@@ -195,4 +204,5 @@ enum spa_video_format xdpw_format_pw_strip_alpha(enum spa_video_format format);
 
 enum xdpw_chooser_types get_chooser_type(const char *chooser_type);
 const char *chooser_type_str(enum xdpw_chooser_types chooser_type);
+void print_screencast_data(struct xdpw_screencast_session_data *data);
 #endif /* SCREENCAST_COMMON_H */

--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -11,7 +11,7 @@
 
 // this seems to be right based on
 // https://github.com/flatpak/xdg-desktop-portal/blob/309a1fc0cf2fb32cceb91dbc666d20cf0a3202c2/src/screen-cast.c#L955
-#define XDP_CAST_PROTO_VER 2
+#define XDP_CAST_PROTO_VER 3
 
 enum cursor_modes {
   HIDDEN = 1,

--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -36,7 +36,7 @@ struct xdpw_session {
 	struct wl_list link;
 	sd_bus_slot *slot;
 	char *session_handle;
-	struct xdpw_screencast_instance *screencast_instance;
+	struct xdpw_screencast_session_data screencast_data;
 };
 
 typedef void (*xdpw_event_loop_timer_func_t)(void *data);
@@ -69,4 +69,5 @@ struct xdpw_timer *xdpw_add_timer(struct xdpw_state *state,
 
 void xdpw_destroy_timer(struct xdpw_timer *timer);
 
+void print_session(struct xdpw_session *sess);
 #endif

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -3,11 +3,19 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include "screencast_common.h"
 #include "xdpw.h"
 #include "screencast.h"
 #include "logger.h"
 
 static const char interface_name[] = "org.freedesktop.impl.portal.Session";
+
+void print_session(struct xdpw_session *sess) {
+	logprint(DEBUG, "Session:");
+	logprint(DEBUG, "Pointer %p", sess);
+	logprint(DEBUG, "Handle %s", sess->session_handle);
+	print_screencast_data(&sess->screencast_data);
+}
 
 static int method_close(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
@@ -61,7 +69,7 @@ void xdpw_session_destroy(struct xdpw_session *sess) {
 	if (!sess) {
 		return;
 	}
-	struct xdpw_screencast_instance *cast = sess->screencast_instance;
+	struct xdpw_screencast_instance *cast = sess->screencast_data.screencast_instance;
 	if (cast) {
 		assert(cast->refcount > 0);
 		--cast->refcount;
@@ -80,6 +88,7 @@ void xdpw_session_destroy(struct xdpw_session *sess) {
 			}
 		}
 	}
+	free(sess->screencast_data.output_name);
 
 	sd_bus_slot_unref(sess->slot);
 	wl_list_remove(&sess->link);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -474,9 +474,10 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 	logprint(DEBUG, "dbus: start: returning node %d", (int)cast->node_id);
 	ret = sd_bus_message_append(reply, "ua{sv}", PORTAL_RESPONSE_SUCCESS, 1,
 		"streams", "a(ua{sv})", 1,
-		cast->node_id, 2,
+		cast->node_id, 3,
 		"position", "(ii)", 0, 0,
 		"size", "(ii)", cast->screencopy_frame_info[WL_SHM].width, cast->screencopy_frame_info[WL_SHM].height);
+		"source_type", "u", 1 << MONITOR);
 
 	if (ret < 0) {
 		return ret;

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -1,5 +1,6 @@
 #include "xdpw.h"
 #include "screencast_common.h"
+#include "logger.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <string.h>
@@ -403,4 +404,11 @@ const char *chooser_type_str(enum xdpw_chooser_types chooser_type) {
 	}
 	fprintf(stderr, "Could not find chooser type %d\n", chooser_type);
 	abort();
+}
+
+void print_screencast_data(struct xdpw_screencast_session_data *data) {
+	logprint(DEBUG, "Session data:");
+	logprint(DEBUG, "Cursormode: %u", data->cursor_mode);
+	logprint(DEBUG, "Persistmode: %u", data->persist_mode);
+	logprint(DEBUG, "Outputname: %s", data->output_name);
 }


### PR DESCRIPTION
This is a first step to restore the session.

While we don't have a choose capable of communicating the option to allow a program to restore the session, we can at least allow transient sessions to be restored via a config option.

This would let users select the output once when using a chromium based browser.