### PR TITLE
contrib/systemd: remove unnecessary `After=` directive

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-wlr.service.in
+++ b/contrib/systemd/xdg-desktop-portal-wlr.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Portal service (wlroots implementation)
 PartOf=graphical-session.target
-After=graphical-session.target
 ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]


### PR DESCRIPTION
`After=graphical-session.target` causes a dependency loop.

If there are user services that depend on the portal and start before `graphical-session.target`, `graphical-session.target` waits for the service, the service waits for `xdg-desktop-portal`, `xdg-desktop-portal` waits for `xdg-desktop-portal-wlr`, and then `xdg-desktop-portal-wlr` waits for `graphical-session.target`.

The service and the portal stuck until `xdg-desktop-portal-wlr` activation timeout (25s).

The compositor must be initialized before GUI apps therefore this directive is not needed.