### PR TITLE
contrib: Add portals config example

### DIFF
--- a/contrib/wlroots-portals.conf
+++ b/contrib/wlroots-portals.conf
@@ -1,0 +1,7 @@
+[preferred]
+# Use xdg-desktop-portal-gtk for every portal interface...
+default=gtk
+# ... except for the Screencast, Screenshot and Settings (dark/light mode) interface
+org.freedesktop.impl.portal.Screencast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr
+org.freedesktop.impl.portal.Settings=darkman


### PR DESCRIPTION
This is an example configuration for choosing the portal implementations which should be used [1]. Compositors and distributions are expected to ship their modified version according to their choice of components.

[1] https://github.com/flatpak/xdg-desktop-portal/pull/955

Resolves: #268 