### PR TITLE
build: drop unused signalfd dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,7 @@ gbm = dependency('gbm')
 drm = dependency('libdrm')
 
 epoll = dependency('', required: false)
-if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
-    not cc.has_function('signalfd', prefix: '#include <sys/signalfd.h>'))
+if not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>')
 	epoll = dependency('epoll-shim')
 endif
 


### PR DESCRIPTION
[NetBSD >= 10.0](https://github.com/netbsd/src/commit/75f1bc6655cf) and [FreeBSD >= 14.0](https://github.com/freebsd/freebsd-src/commit/af93fea71038) have native `timerfd` support. `git log -p` doesn't show any `signalfd` references.

See also [build log](https://github.com/emersion/xdg-desktop-portal-wlr/files/12447597/xdg-desktop-portal-wlr-0.7.0.3.log).
