### PR TITLE
Remove unused calls to xdpw_request_create

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -263,12 +263,6 @@ static int method_screencast_create_session(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	struct xdpw_request *req =
-		xdpw_request_create(sd_bus_message_get_bus(msg), request_handle);
-	if (req == NULL) {
-		return -ENOMEM;
-	}
-
 	struct xdpw_session *sess =
 		xdpw_session_create(state, sd_bus_message_get_bus(msg), strdup(session_handle));
 	if (sess == NULL) {

--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -109,13 +109,6 @@ static int method_screenshot(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	// TODO: cleanup this
-	struct xdpw_request *req =
-		xdpw_request_create(sd_bus_message_get_bus(msg), handle);
-	if (req == NULL) {
-		return -ENOMEM;
-	}
-
 	// TODO: choose a better path
 	const char path[] = "/tmp/out.png";
 	if (interactive && !exec_screenshooter_interactive(path)) {
@@ -245,12 +238,6 @@ static int method_pick_color(sd_bus_message *msg, void *data,
 	ret = sd_bus_message_read(msg, "oss", &handle, &app_id, &parent_window);
 	if (ret < 0) {
 		return ret;
-	}
-
-	struct xdpw_request *req =
-		xdpw_request_create(sd_bus_message_get_bus(msg), handle);
-	if (req == NULL) {
-		return -ENOMEM;
 	}
 
 	struct xdpw_ppm_pixel pixel = {0};


### PR DESCRIPTION
The req object was not used and these calls were resulting with an error when attempting the pick-color from kdenlive on ubuntu 22.04 and 23.04

These objects were also not freed which is a memory leak.