### PR TITLE
Screencast response fixes

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -127,6 +127,7 @@ struct xdpw_screencast_context {
 	struct wl_shm *shm;
 	struct zwp_linux_dmabuf_v1 *linux_dmabuf;
 	struct zwp_linux_dmabuf_feedback_v1 *linux_dmabuf_feedback;
+	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct xdpw_dmabuf_feedback_data feedback_data;
 	struct wl_array format_modifier_pairs;
 
@@ -194,9 +195,12 @@ struct xdpw_wlr_output {
 	struct wl_list link;
 	uint32_t id;
 	struct wl_output *output;
+	struct zxdg_output_v1 *xdg_output;
 	char *make;
 	char *model;
 	char *name;
+	int x;
+	int y;
 	int width;
 	int height;
 	float framerate;

--- a/include/wlr_screencast.h
+++ b/include/wlr_screencast.h
@@ -13,6 +13,9 @@
 #define LINUX_DMABUF_VERSION 4
 #define LINUX_DMABUF_VERSION_MIN 3
 
+#define XDG_OUTPUT_VERSION 3
+#define XDG_OUTPUT_VERSION_MIN 1
+
 struct xdpw_state;
 
 int xdpw_wlr_screencopy_init(struct xdpw_state *state);

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -585,12 +585,73 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 	if (ret < 0) {
 		return ret;
 	}
-	ret = sd_bus_message_append(reply, "{sv}",
-		"streams", "a(ua{sv})", 1,
-		cast->node_id, 3,
-		"position", "(ii)", 0, 0,
-		"size", "(ii)", cast->screencopy_frame_info[WL_SHM].width, cast->screencopy_frame_info[WL_SHM].height,
-		"source_type", "u", MONITOR);
+	ret = sd_bus_message_open_container(reply, 'e', "sv");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_append(reply, "s", "streams");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'v', "a(ua{sv})");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'a', "(ua{sv})");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'r', "ua{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_append(reply, "u", cast->node_id);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	if (cast->target->output->xdg_output) {
+		ret = sd_bus_message_append(reply, "{sv}",
+			"position", "(ii)", cast->target->output->x, cast->target->output->y);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = sd_bus_message_append(reply, "{sv}",
+			"size", "(ii)", cast->target->output->width, cast->target->output->height);
+		if (ret < 0) {
+			return ret;
+		}
+	} else {
+		ret = sd_bus_message_append(reply, "{sv}",
+			"size", "(ii)", cast->screencopy_frame_info[WL_SHM].width, cast->screencopy_frame_info[WL_SHM].height);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	ret = sd_bus_message_append(reply, "{sv}", "source_type", "u", MONITOR);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
 	if (ret < 0) {
 		return ret;
 	}

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -624,12 +624,6 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 		if (ret < 0) {
 			return ret;
 		}
-	} else {
-		ret = sd_bus_message_append(reply, "{sv}",
-			"size", "(ii)", cast->screencopy_frame_info[WL_SHM].width, cast->screencopy_frame_info[WL_SHM].height);
-		if (ret < 0) {
-			return ret;
-		}
 	}
 	ret = sd_bus_message_append(reply, "{sv}", "source_type", "u", MONITOR);
 	if (ret < 0) {


### PR DESCRIPTION
This PR fixes 2 errors in the response returned by the screencast interface:

- The source type was wrong (`1 << MONITOR` -> `MONITOR`).
- The position was hardcoded as (0, 0). If the compositor supports the xdg-output protocol, use that protocol to get the correct position and report it. Otherwise, omit the position entirely.