### PR TITLE
Drop wlr.portal

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,11 +105,6 @@ configure_file(
 	install_dir: get_option('datadir') / 'dbus-1' / 'services',
 )
 
-install_data(
-	'wlr.portal',
-	install_dir: get_option('datadir') / 'xdg-desktop-portal' / 'portals',
-)
-
 scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7', native: true)
 if scdoc.found()
 	scdoc_prog = find_program(scdoc.get_variable(pkgconfig: 'scdoc'), native: true)

--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,0 @@
-[portal]
-DBusName=org.freedesktop.impl.portal.desktop.wlr
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=wlroots;sway;Wayfire;river;phosh;Hyprland;


### PR DESCRIPTION
xdg-desktop-portal has a new way to find portal implementations now.