### PR TITLE
build: don't use cc.get_supported_arguments() for -D flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,12 +13,14 @@ add_project_arguments(cc.get_supported_arguments([
 	'-Wno-missing-braces',
 	'-Wno-missing-field-initializers',
 	'-Wno-unused-parameter',
-	'-D_POSIX_C_SOURCE=200809L',
 ]), language: 'c')
 
 prefix = get_option('prefix')
 sysconfdir = get_option('sysconfdir')
-add_project_arguments('-DSYSCONFDIR="@0@"'.format(prefix / sysconfdir), language : 'c')
+add_project_arguments([
+	'-D_POSIX_C_SOURCE=200809L',
+	'-DSYSCONFDIR="@0@"'.format(prefix / sysconfdir),
+], language: 'c')
 
 inc = include_directories('include')
 


### PR DESCRIPTION
If somehow the compiler doesn't support -D, we should fail hard instead of omitting the define. Should also speed up Meson setup time a bit.