### PR TITLE
build: add summary for auto-detected features

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -132,3 +132,9 @@ if scdoc.found()
 		)
 	endforeach
 endif
+
+summary({
+	'sd-bus provider': sdbus.name(),
+	'systemd service': systemd.found(),
+	'Man pages': scdoc.found(),
+}, bool_yn: true)


### PR DESCRIPTION
Makes it easier to tell if something has been auto-disabled due to
a missing dependency.