### PR TITLE
colorchooser: force grim to only return a single pixel

### DIFF
--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -160,7 +160,7 @@ static bool spawn_chooser(int chooser_out[2]) {
 		dup2(chooser_out[1], STDOUT_FILENO);
 		close(chooser_out[1]);
 
-		execl("/bin/sh", "/bin/sh", "-c", "grim -g \"$(slurp -p)\" -t ppm -", NULL);
+		execl("/bin/sh", "/bin/sh", "-c", "grim -s 1 -g \"$(slurp -p)\" -t ppm -", NULL);
 
 		perror("execl");
 		_exit(127);


### PR DESCRIPTION
On scaled outputs grim returns scaled images.
This breaks the enforced invariant in exec_color_picker() to expect single pixel images.

Force grim to use a scale of "1" to avoid this.