### PR TITLE
 colorchooser: clean up xdpw request

### DIFF
--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -265,21 +265,22 @@ static int method_pick_color(sd_bus_message *msg, void *data,
 	sd_bus_message *reply = NULL;
 	ret = sd_bus_message_new_method_return(msg, &reply);
 	if (ret < 0) {
-		return ret;
+		goto unref_reply;
 	}
 
 	ret = sd_bus_message_append(reply, "ua{sv}", PORTAL_RESPONSE_SUCCESS, 1, "color", "(ddd)", red, green, blue);
 	if (ret < 0) {
-		return ret;
+		goto unref_reply;
 	}
 
 	ret = sd_bus_send(NULL, reply, NULL);
 	if (ret < 0) {
-		return ret;
+		goto unref_reply;
 	}
 
+unref_reply:
 	sd_bus_message_unref(reply);
-	return 0;
+	return ret;
 }
 
 static const sd_bus_vtable screenshot_vtable[] = {

--- a/src/screenshot/screenshot.c
+++ b/src/screenshot/screenshot.c
@@ -255,7 +255,8 @@ static int method_pick_color(sd_bus_message *msg, void *data,
 
 	struct xdpw_ppm_pixel pixel = {0};
 	if (!exec_color_picker(&pixel)) {
-		return -1;
+		ret = -1;
+		goto destroy_request;
 	}
 
 	double red = pixel.red / (pixel.max_color_value * 1.0);
@@ -280,6 +281,8 @@ static int method_pick_color(sd_bus_message *msg, void *data,
 
 unref_reply:
 	sd_bus_message_unref(reply);
+destroy_request:
+	xdpw_request_destroy(req);
 	return ret;
 }
 


### PR DESCRIPTION
The xdpw request creates an object on the bus.
Not removing it means that the next call to method_pick_color() will
fail as the old object is still around.

Also make sure to clean up in error cases.
