### PR TITLE
screencast: fix SelectSources type bitmask check

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -341,7 +341,7 @@ static int method_screencast_select_sources(sd_bus_message *msg, void *data,
 		} else if (strcmp(key, "types") == 0) {
 			uint32_t mask;
 			sd_bus_message_read(msg, "v", "u", &mask);
-			if (mask & (1<<WINDOW)) {
+			if (!(mask & MONITOR)) {
 				logprint(INFO, "dbus: non-monitor cast requested, not replying");
 				return -1;
 			}


### PR DESCRIPTION
In the same vein as aff78aeecd324034c6e7e976f0156c04e83f6459, `WINDOW` is the value and not the index in the bitmask. But additionally, as I understand it, a "non-monitor" source type would be one that lacks `MONITOR` rather than one that includes `WINDOW` (or `VIRTUAL`) at all.

Technically this is a change in behavior since previously `WINDOW`-only source types were accepted but treated as `MONITOR` source types, and those will now be rejected (as only `VIRTUAL` source types were technically checked by mistake due to the bitmask value/index checking bug).