### PR TITLE
Implement RemoteDesktop protocol

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -10,6 +10,7 @@ packages:
   - scdoc
   - libdrm
   - mesa-dev
+  - libxkbcommon-dev
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -9,6 +9,7 @@ packages:
   - libinih
   - scdoc
   - mesa
+  - libxkbcommon
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -11,6 +11,7 @@ packages:
   - scdoc
   - graphics/libdrm
   - graphics/mesa-libs
+  - libxkbcommon
 sources:
   - https://github.com/emersion/xdg-desktop-portal-wlr
 tasks:

--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <stdint.h>
+
 #include "logger.h"
 #include "screencast_common.h"
 
@@ -14,8 +16,13 @@ struct config_screencast {
 	bool force_mod_linear;
 };
 
+struct config_remotedesktop {
+	uint32_t allowed_devices;
+};
+
 struct xdpw_config {
 	struct config_screencast screencast_conf;
+	struct config_remotedesktop remotedesktop_conf;
 };
 
 void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config);

--- a/include/intset.h
+++ b/include/intset.h
@@ -1,0 +1,37 @@
+/*
+ * Copied from wayvnc: https://github.com/any1/wayvnc/
+ *
+ * Copyright (c) 2020 Andri Yngvason
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+struct intset {
+	size_t cap;
+	size_t len;
+	int32_t* storage;
+};
+
+int intset_init(struct intset* self, size_t cap);
+void intset_destroy(struct intset* self);
+
+int intset_set(struct intset* self, int32_t value);
+void intset_clear(struct intset* self, int32_t value);
+
+bool intset_is_set(const struct intset* self, int32_t value);

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -1,0 +1,48 @@
+/*
+ * Copied from wayvnc: https://github.com/any1/wayvnc/
+ *
+ * Copyright (c) 2019 Andri Yngvason
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <xkbcommon/xkbcommon.h>
+#include <stdbool.h>
+
+#include "intset.h"
+
+struct zwp_virtual_keyboard_v1;
+struct table_entry;
+
+struct keyboard {
+	struct zwp_virtual_keyboard_v1* virtual_keyboard;
+
+	struct xkb_context* context;
+	struct xkb_keymap* keymap;
+	struct xkb_state* state;
+
+	size_t lookup_table_size;
+	size_t lookup_table_length;
+	struct table_entry* lookup_table;
+
+	struct intset key_state;
+};
+
+int keyboard_init(struct keyboard* self, const struct xkb_rule_names* rule_names);
+void keyboard_destroy(struct keyboard* self);
+void keyboard_feed(struct keyboard* self, xkb_keysym_t symbol, bool is_pressed);
+void keyboard_feed_code(struct keyboard* self, xkb_keycode_t code,
+		bool is_pressed);

--- a/include/remotedesktop.h
+++ b/include/remotedesktop.h
@@ -1,0 +1,8 @@
+#ifndef REMOTE_DESKTOP_H
+#define REMOTE_DESKTOP_H
+
+#include "remotedesktop_common.h"
+
+void xdpw_remotedesktop_destroy(struct xdpw_remotedesktop_session_data *data);
+
+#endif

--- a/include/remotedesktop_common.h
+++ b/include/remotedesktop_common.h
@@ -16,6 +16,13 @@ struct xdpw_remotedesktop_context {
 };
 
 struct xdpw_remotedesktop_session_data {
+	uint32_t devices;
+};
+
+enum device_types {
+	KEYBOARD = 1,
+	POINTER = 2,
+	TOUCHSCREEN = 4,
 };
 
 #endif

--- a/include/remotedesktop_common.h
+++ b/include/remotedesktop_common.h
@@ -1,0 +1,21 @@
+#ifndef REMOTEDESKTOP_COMMON_H
+#define REMOTEDESKTOP_COMMON_H
+
+#include <stdbool.h>
+
+#include <wayland-client-protocol.h>
+
+#define XDP_REMOTE_PROTO_VER 1
+
+struct xdpw_remotedesktop_context {
+	// xdpw
+	struct xdpw_state *state;
+
+	// sessions
+	struct wl_list remotedesktop_instances;
+};
+
+struct xdpw_remotedesktop_session_data {
+};
+
+#endif

--- a/include/remotedesktop_common.h
+++ b/include/remotedesktop_common.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <wayland-client-protocol.h>
 
+#include "keyboard.h"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
 #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 
 #define XDP_REMOTE_PROTO_VER 1
@@ -15,6 +17,8 @@ struct xdpw_remotedesktop_context {
 	// wlroots
 	struct wl_registry *registry;
 	struct zwlr_virtual_pointer_manager_v1 *virtual_pointer_manager;
+	struct zwp_virtual_keyboard_manager_v1 *virtual_keyboard_manager;
+	struct wl_seat *seat;
 
 	// sessions
 	struct wl_list remotedesktop_instances;
@@ -22,6 +26,7 @@ struct xdpw_remotedesktop_context {
 
 struct xdpw_remotedesktop_session_data {
 	struct zwlr_virtual_pointer_v1 *virtual_pointer;
+	struct keyboard keyboard;
 	uint32_t devices;
 	uint32_t pressed_buttons;
 };

--- a/include/remotedesktop_common.h
+++ b/include/remotedesktop_common.h
@@ -2,8 +2,9 @@
 #define REMOTEDESKTOP_COMMON_H
 
 #include <stdbool.h>
-
 #include <wayland-client-protocol.h>
+
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 
 #define XDP_REMOTE_PROTO_VER 1
 
@@ -11,12 +12,18 @@ struct xdpw_remotedesktop_context {
 	// xdpw
 	struct xdpw_state *state;
 
+	// wlroots
+	struct wl_registry *registry;
+	struct zwlr_virtual_pointer_manager_v1 *virtual_pointer_manager;
+
 	// sessions
 	struct wl_list remotedesktop_instances;
 };
 
 struct xdpw_remotedesktop_session_data {
+	struct zwlr_virtual_pointer_v1 *virtual_pointer;
 	uint32_t devices;
+	uint32_t pressed_buttons;
 };
 
 enum device_types {
@@ -24,5 +31,7 @@ enum device_types {
 	POINTER = 2,
 	TOUCHSCREEN = 4,
 };
+
+uint32_t get_time_ms();
 
 #endif

--- a/include/screencast.h
+++ b/include/screencast.h
@@ -6,4 +6,6 @@
 void xdpw_screencast_instance_destroy(struct xdpw_screencast_instance *cast);
 void xdpw_screencast_instance_teardown(struct xdpw_screencast_instance *cast);
 
+int xdpw_screencast_start(struct xdpw_screencast_instance *cast);
+
 #endif

--- a/include/shm_util.h
+++ b/include/shm_util.h
@@ -1,0 +1,9 @@
+#ifndef SHM_H
+#define SHM_H
+
+#include <unistd.h>
+
+void randname(char *buf);
+int anonymous_shm_open(void);
+
+#endif

--- a/include/shm_util.h
+++ b/include/shm_util.h
@@ -5,5 +5,6 @@
 
 void randname(char *buf);
 int anonymous_shm_open(void);
+int shm_alloc_fd(size_t size);
 
 #endif

--- a/include/virtual_input.h
+++ b/include/virtual_input.h
@@ -1,0 +1,15 @@
+#ifndef VIRTUAL_INPUT_H
+#define VIRTUAL_INPUT_H
+
+#define VIRTUAL_POINTER_VERSION 2
+#define VIRTUAL_POINTER_VERSION_MIN 1
+
+#include "remotedesktop_common.h"
+
+struct xdpw_state;
+
+int xdpw_virtual_input_init(struct xdpw_state *state);
+
+void xdpw_virtual_input_finish(struct xdpw_remotedesktop_context *ctx);
+
+#endif

--- a/include/virtual_input.h
+++ b/include/virtual_input.h
@@ -4,6 +4,9 @@
 #define VIRTUAL_POINTER_VERSION 2
 #define VIRTUAL_POINTER_VERSION_MIN 1
 
+#define VIRTUAL_KEYBOARD_VERSION 1
+#define VIRTUAL_KEYBOARD_VERSION_MIN 1
+
 #include "remotedesktop_common.h"
 
 struct xdpw_state;

--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -12,6 +12,7 @@
 
 #include "screencast_common.h"
 #include "screenshot_common.h"
+#include "remotedesktop_common.h"
 #include "config.h"
 
 struct xdpw_state {
@@ -24,6 +25,9 @@ struct xdpw_state {
 	uint32_t screencast_cursor_modes; // bitfield of enum cursor_modes
 	uint32_t screencast_version;
 	uint32_t screenshot_version;
+	struct xdpw_remotedesktop_context remotedesktop;
+	uint32_t remotedesktop_version;
+	uint32_t remotedesktop_available_device_types;
 	struct xdpw_config *config;
 	int timer_poll_fd;
 	struct wl_list timers;
@@ -40,6 +44,7 @@ struct xdpw_session {
 	char *session_handle;
 	bool closed;
 	struct xdpw_screencast_session_data screencast_data;
+	struct xdpw_remotedesktop_session_data remotedesktop_data;
 };
 
 typedef void (*xdpw_event_loop_timer_func_t)(void *data);
@@ -60,6 +65,7 @@ enum {
 
 int xdpw_screenshot_init(struct xdpw_state *state);
 int xdpw_screencast_init(struct xdpw_state *state);
+int xdpw_remotedesktop_init(struct xdpw_state *state);
 
 struct xdpw_request *xdpw_request_create(sd_bus *bus, const char *object_path);
 void xdpw_request_destroy(struct xdpw_request *req);

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.24')
 iniparser = dependency('inih')
 gbm = dependency('gbm')
 drm = dependency('libdrm')
+xkbcommon = dependency('xkbcommon')
 
 epoll = dependency('', required: false)
 if not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>')
@@ -66,9 +67,11 @@ xdpw_files = files(
 	'src/screencast/wlr_screencopy.c',
 	'src/screencast/pipewire_screencast.c',
 	'src/screencast/fps_limit.c',
+	'src/remotedesktop/intset.c',
 	'src/remotedesktop/remotedesktop.c',
 	'src/remotedesktop/remotedesktop_common.c',
 	'src/remotedesktop/virtual_input.c',
+	'src/remotedesktop/keyboard.c',
 )
 
 executable(
@@ -83,6 +86,7 @@ executable(
 		gbm,
 		drm,
 		epoll,
+		xkbcommon,
 	],
 	include_directories: [inc],
 	install: true,

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ xdpw_files = files(
 	'src/core/config.c',
 	'src/core/request.c',
 	'src/core/session.c',
+	'src/core/shm_util.c',
 	'src/core/string_util.c',
 	'src/core/timer.c',
 	'src/core/timespec_util.c',

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ xdpw_files = files(
 	'src/screencast/wlr_screencopy.c',
 	'src/screencast/pipewire_screencast.c',
 	'src/screencast/fps_limit.c',
+	'src/remotedesktop/remotedesktop.c',
 )
 
 executable(

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,8 @@ xdpw_files = files(
 	'src/screencast/pipewire_screencast.c',
 	'src/screencast/fps_limit.c',
 	'src/remotedesktop/remotedesktop.c',
+	'src/remotedesktop/remotedesktop_common.c',
+	'src/remotedesktop/virtual_input.c',
 )
 
 executable(

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -13,6 +13,7 @@ client_protocols = [
 	wl_protocol_dir / 'staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml',
 	wl_protocol_dir / 'staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml',
 	'wlr-screencopy-unstable-v1.xml',
+	'wlr-virtual-pointer-unstable-v1.xml',
 ]
 
 wl_proto_files = []

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -14,6 +14,7 @@ client_protocols = [
 	wl_protocol_dir / 'staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml',
 	'wlr-screencopy-unstable-v1.xml',
 	'wlr-virtual-pointer-unstable-v1.xml',
+	'virtual-keyboard-unstable-v1.xml',
 ]
 
 wl_proto_files = []

--- a/protocols/virtual-keyboard-unstable-v1.xml
+++ b/protocols/virtual-keyboard-unstable-v1.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="virtual_keyboard_unstable_v1">
+  <copyright>
+    Copyright © 2008-2011  Kristian Høgsberg
+    Copyright © 2010-2013  Intel Corporation
+    Copyright © 2012-2013  Collabora, Ltd.
+    Copyright © 2018       Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_virtual_keyboard_v1" version="1">
+    <description summary="virtual keyboard">
+      The virtual keyboard provides an application with requests which emulate
+      the behaviour of a physical keyboard.
+
+      This interface can be used by clients on its own to provide raw input
+      events, or it can accompany the input method protocol.
+    </description>
+
+    <request name="keymap">
+      <description summary="keyboard mapping">
+        Provide a file descriptor to the compositor which can be
+        memory-mapped to provide a keyboard mapping description.
+
+        Format carries a value from the keymap_format enumeration.
+      </description>
+      <arg name="format" type="uint" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </request>
+
+    <enum name="error">
+      <entry name="no_keymap" value="0" summary="No keymap was set"/>
+    </enum>
+
+    <request name="key">
+      <description summary="key event">
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond granularity, with an
+        undefined base. All requests regarding a single object must share the
+        same clock.
+
+        Keymap must be set before issuing this request.
+
+        State carries a value from the key_state enumeration.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" summary="physical state of the key"/>
+    </request>
+
+    <request name="modifiers">
+      <description summary="modifier and group state">
+        Notifies the compositor that the modifier and/or group state has
+        changed, and it should update state.
+
+        The client should use wl_keyboard.modifiers event to synchronize its
+        internal state with seat state.
+
+        Keymap must be set before issuing this request.
+      </description>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual keyboard keyboard object"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_virtual_keyboard_manager_v1" version="1">
+    <description summary="virtual keyboard manager">
+      A virtual keyboard manager allows an application to provide keyboard
+      input events as if they came from a physical keyboard.
+    </description>
+
+    <enum name="error">
+      <entry name="unauthorized" value="0" summary="client not authorized to use the interface"/>
+    </enum>
+
+    <request name="create_virtual_keyboard">
+      <description summary="Create a new virtual keyboard">
+        Creates a new virtual keyboard associated to a seat.
+
+        If the compositor enables a keyboard to perform arbitrary actions, it
+        should present an error when an untrusted client requests a new
+        keyboard.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="zwp_virtual_keyboard_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocols/wlr-virtual-pointer-unstable-v1.xml
+++ b/protocols/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "remotedesktop_common.h"
 #include "xdpw.h"
 #include "logger.h"
 #include "screencast_common.h"
@@ -85,12 +86,35 @@ static int handle_ini_screencast(struct config_screencast *screencast_conf, cons
 	return 1;
 }
 
+static int handle_ini_remotedesktop(struct config_remotedesktop *conf, const char *key, const char *value) {
+	uint32_t device;
+	if (strcmp(key, "allow_keyboard") == 0) {
+		device = KEYBOARD;
+	} else if (strcmp(key, "allow_pointer") == 0) {
+		device = POINTER;
+	} else {
+		logprint(TRACE, "config: skipping invalid key in config file");
+		return 0;
+	}
+	bool is_allowed = (conf->allowed_devices & device) != 0;
+	parse_bool(&is_allowed, value);
+	if (is_allowed) {
+		conf->allowed_devices |= device;
+	} else {
+		conf->allowed_devices &= ~device;
+	}
+	return 1;
+}
+
 static int handle_ini_config(void *data, const char* section, const char *key, const char *value) {
 	struct xdpw_config *config = (struct xdpw_config*)data;
 	logprint(TRACE, "config: parsing setction %s, key %s, value %s", section, key, value);
 
 	if (strcmp(section, "screencast") == 0) {
 		return handle_ini_screencast(&config->screencast_conf, key, value);
+	}
+	if (strcmp(section, "remotedesktop") == 0) {
+		return handle_ini_remotedesktop(&config->remotedesktop_conf, key, value);
 	}
 
 	logprint(TRACE, "config: skipping invalid key in config file");
@@ -100,6 +124,7 @@ static int handle_ini_config(void *data, const char* section, const char *key, c
 static void default_config(struct xdpw_config *config) {
 	config->screencast_conf.max_fps = 0;
 	config->screencast_conf.chooser_type = XDPW_CHOOSER_DEFAULT;
+	config->remotedesktop_conf.allowed_devices = KEYBOARD | POINTER;
 }
 
 static bool file_exists(const char *path) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/timerfd.h>
@@ -8,6 +9,7 @@
 #include <spa/utils/result.h>
 #include <unistd.h>
 
+#include "remotedesktop_common.h"
 #include "xdpw.h"
 #include "logger.h"
 
@@ -120,7 +122,7 @@ int main(int argc, char *argv[]) {
 		.screencast_cursor_modes = HIDDEN | EMBEDDED,
 		.screencast_version = XDP_CAST_PROTO_VER,
 		.screenshot_version = XDP_SHOT_PROTO_VER,
-		.remotedesktop_available_device_types = 0,
+		.remotedesktop_available_device_types = config.remotedesktop_conf.allowed_devices,
 		.remotedesktop_version = XDP_REMOTE_PROTO_VER,
 		.config = &config,
 	};

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -120,6 +120,8 @@ int main(int argc, char *argv[]) {
 		.screencast_cursor_modes = HIDDEN | EMBEDDED,
 		.screencast_version = XDP_CAST_PROTO_VER,
 		.screenshot_version = XDP_SHOT_PROTO_VER,
+		.remotedesktop_available_device_types = 0,
+		.remotedesktop_version = XDP_REMOTE_PROTO_VER,
 		.config = &config,
 	};
 
@@ -134,6 +136,12 @@ int main(int argc, char *argv[]) {
 	ret = xdpw_screencast_init(&state);
 	if (ret < 0) {
 		logprint(ERROR, "xdpw: failed to initialize screencast");
+		goto error;
+	}
+
+	ret = xdpw_remotedesktop_init(&state);
+	if (ret < 0) {
+		logprint(ERROR, "xdpw: failed to initialize remotedesktop");
 		goto error;
 	}
 

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include "xdpw.h"
 #include "screencast.h"
+#include "remotedesktop.h"
 #include "logger.h"
 
 static const char interface_name[] = "org.freedesktop.impl.portal.Session";
@@ -84,6 +85,9 @@ void xdpw_session_destroy(struct xdpw_session *sess) {
 			xdpw_screencast_instance_destroy(cast);
 		}
 	}
+
+	xdpw_remotedesktop_destroy(&sess->remotedesktop_data);
+
 	free(sess->session_handle);
 	free(sess);
 }

--- a/src/core/shm_util.c
+++ b/src/core/shm_util.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "shm_util.h"
+
+void randname(char *buf) {
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	long r = ts.tv_nsec;
+	for (int i = 0; i < 6; ++i) {
+		assert(buf[i] == 'X');
+		buf[i] = 'A'+(r&15)+(r&16)*2;
+		r >>= 5;
+	}
+}
+
+int anonymous_shm_open(void) {
+	char name[] = "/xdpw-shm-XXXXXX";
+	int retries = 100;
+
+	do {
+		randname(name + strlen(name) - 6);
+
+		--retries;
+		// shm_open guarantees that O_CLOEXEC is set
+		int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+		if (fd >= 0) {
+			shm_unlink(name);
+			return fd;
+		}
+	} while (retries > 0 && errno == EEXIST);
+
+	return -1;
+}

--- a/src/core/shm_util.c
+++ b/src/core/shm_util.c
@@ -37,3 +37,22 @@ int anonymous_shm_open(void) {
 
 	return -1;
 }
+
+int shm_alloc_fd(size_t size)
+{
+	int fd = anonymous_shm_open();
+	if (fd < 0)
+		return -1;
+
+	int ret;
+	do {
+		ret = ftruncate(fd, size);
+	} while (ret < 0 && errno == EINTR);
+
+	if (ret < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}

--- a/src/remotedesktop/intset.c
+++ b/src/remotedesktop/intset.c
@@ -1,0 +1,97 @@
+/*
+ * Copied from wayvnc: https://github.com/any1/wayvnc/
+ *
+ * Copyright (c) 2020 Andri Yngvason
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "intset.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#define DEFAULT_CAPACITY 256
+
+int intset_init(struct intset* self, size_t cap)
+{
+	if (cap == 0)
+		cap = DEFAULT_CAPACITY;
+
+	memset(self, 0, sizeof(*self));
+
+	self->storage = malloc(cap * sizeof(*self->storage));
+	if (!self->storage)
+		return -1;
+
+	self->cap = cap;
+
+	return 0;
+}
+
+void intset_destroy(struct intset* self)
+{
+	free(self->storage);
+	memset(self, 0, sizeof(*self));
+}
+
+static int intset__grow(struct intset*  self)
+{
+	size_t new_cap = self->cap * 2;
+
+	int32_t* new_storage = realloc(self->storage, new_cap);
+	if (!new_storage)
+		return -1;
+
+	self->storage = new_storage;
+	self->cap = new_cap;
+
+	return 0;
+}
+
+int intset_set(struct intset* self, int32_t value)
+{
+	if (intset_is_set(self, value))
+		return 0;
+
+	if (self->len >= self->cap && intset__grow(self) < 0)
+		return -1;
+
+	self->storage[self->len++] = value;
+
+	return 0;
+}
+
+static ssize_t intset__find_index(const struct intset* self, int32_t value)
+{
+	for (size_t i = 0; i < self->len; ++i)
+		if (self->storage[i] == value)
+			return i;
+
+	return -1;
+}
+
+void intset_clear(struct intset* self, int32_t value)
+{
+	ssize_t index = intset__find_index(self, value);
+	if (index < 0)
+		return;
+
+	self->storage[index] = self->storage[--self->len];
+}
+
+bool intset_is_set(const struct intset* self, int32_t value)
+{
+	return intset__find_index(self, value) >= 0;
+}

--- a/src/remotedesktop/keyboard.c
+++ b/src/remotedesktop/keyboard.c
@@ -1,0 +1,445 @@
+/*
+ * Copied from wayvnc: https://github.com/any1/wayvnc/
+ * Modified to add time info to send keycodes and remove neatvnc dependency.
+ *
+ * Copyright (c) 2019 - 2020 Andri Yngvason
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Acknowledgements: Reading Josef Gajdusek's wvnc code helped me understand
+ * how to use the xkbcommon API to interface with the wayland virtual keyboard
+ * interface.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+#include <wayland-client-protocol.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
+#include <xkbcommon/xkbcommon.h>
+#include <wayland-client.h>
+
+#include "intset.h"
+#include "keyboard.h"
+#include "logger.h"
+#include "remotedesktop_common.h"
+#include "shm_util.h"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
+
+#define MAYBE_UNUSED __attribute__((unused))
+
+struct table_entry {
+	xkb_keysym_t symbol;
+	xkb_keycode_t code;
+	int level;
+};
+
+struct kb_mods {
+	xkb_mod_mask_t depressed, latched, locked;
+};
+
+static void append_entry(struct keyboard* self, xkb_keysym_t symbol,
+                         xkb_keycode_t code, int level)
+{
+	if (self->lookup_table_size <= self->lookup_table_length) {
+		size_t new_size = self->lookup_table_size * 2;
+		struct table_entry* table =
+			realloc(self->lookup_table, new_size * sizeof(*table));
+		if (!table)
+			return; // TODO: Report this
+
+		self->lookup_table_size = new_size;
+		self->lookup_table = table;
+	}
+
+	struct table_entry* entry =
+		&self->lookup_table[self->lookup_table_length++];
+
+	entry->symbol = symbol;
+	entry->code = code;
+	entry->level = level;
+}
+
+static void key_iter(struct xkb_keymap* map, xkb_keycode_t code, void* userdata)
+{
+	struct keyboard* self = userdata;
+
+	size_t n_levels = xkb_keymap_num_levels_for_key(map, code, 0);
+
+	for (size_t level = 0; level < n_levels; level++) {
+		const xkb_keysym_t* symbols;
+		size_t n_syms = xkb_keymap_key_get_syms_by_level(map, code, 0,
+				                                 level,
+				                                 &symbols);
+
+		for (size_t sym_idx = 0; sym_idx < n_syms; sym_idx++)
+			append_entry(self, symbols[sym_idx], code, level);
+	}
+}
+
+static int compare_symbols(const void* a, const void* b)
+{
+	const struct table_entry* x = a;
+	const struct table_entry* y = b;
+
+	if (x->symbol == y->symbol)
+		return x->code < y->code ? -1 : x->code > y->code;
+
+	return x->symbol < y->symbol ? -1 : x->symbol > y->symbol;
+}
+
+static int compare_symbols2(const void* a, const void* b)
+{
+	const struct table_entry* x = a;
+	const struct table_entry* y = b;
+
+	return x->symbol < y->symbol ? -1 : x->symbol > y->symbol;
+}
+
+static int create_lookup_table(struct keyboard* self)
+{
+	self->lookup_table_length = 0;
+	self->lookup_table_size = 128;
+
+	self->lookup_table =
+		malloc(self->lookup_table_size * sizeof(*self->lookup_table));
+	if (!self->lookup_table)
+		return -1;
+
+	xkb_keymap_key_for_each(self->keymap, key_iter, self);
+
+	qsort(self->lookup_table, self->lookup_table_length,
+	      sizeof(*self->lookup_table), compare_symbols);
+
+	return 0;
+}
+
+static char* get_symbol_name(xkb_keysym_t sym, char* dst, size_t size)
+{
+	if (xkb_keysym_get_name(sym, dst, size) >= 0)
+		return dst;
+
+	snprintf(dst, size, "UNKNOWN (%x)", sym);
+	return dst;
+}
+
+static void keyboard__dump_entry(const struct keyboard* self,
+                                 const struct table_entry* entry)
+{
+	char sym_name[256];
+	get_symbol_name(entry->symbol, sym_name, sizeof(sym_name));
+
+	const char* code_name MAYBE_UNUSED =
+		xkb_keymap_key_get_name(self->keymap, entry->code);
+
+	bool is_pressed MAYBE_UNUSED =
+		intset_is_set(&self->key_state, entry->code);
+
+	logprint(DEBUG, "symbol=%s level=%d code=%s %s", sym_name, entry->level,
+	          code_name, is_pressed ? "pressed" : "released");
+}
+
+void keyboard_dump_lookup_table(const struct keyboard* self)
+{
+	for (size_t i = 0; i < self->lookup_table_length; i++)
+		keyboard__dump_entry(self, &self->lookup_table[i]);
+}
+
+int keyboard_init(struct keyboard* self, const struct xkb_rule_names* rule_names)
+{
+	self->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	if (!self->context)
+		return -1;
+
+	if (intset_init(&self->key_state, 0) < 0)
+		goto key_state_failure;
+
+	self->keymap = xkb_keymap_new_from_names(self->context, rule_names,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+	if (!self->keymap)
+		goto keymap_failure;
+
+	if (xkb_keymap_num_layouts(self->keymap) > 1)
+		logprint(WARN, "Multiple keyboard layouts have been specified, but only one is supported.");
+
+	self->state = xkb_state_new(self->keymap);
+	if (!self->state)
+		goto state_failure;
+
+	if (create_lookup_table(self) < 0)
+		goto table_failure;
+
+//	keyboard_dump_lookup_table(self);
+
+	char* keymap_string =
+		xkb_keymap_get_as_string(self->keymap,
+		                         XKB_KEYMAP_FORMAT_TEXT_V1);
+	if (!keymap_string)
+		goto keymap_string_failure;
+
+	size_t keymap_size = strlen(keymap_string) + 1;
+
+	int keymap_fd = shm_alloc_fd(keymap_size);
+	if (keymap_fd < 0)
+		goto fd_failure;
+
+	size_t written = 0;
+	while (written < keymap_size) {
+		ssize_t ret = write(keymap_fd, keymap_string + written, keymap_size - written);
+		if (ret == -1 && errno == EINTR)
+			continue;
+		if (ret == -1)
+			goto write_failure;
+		written += ret;
+	}
+
+	free(keymap_string);
+
+	zwp_virtual_keyboard_v1_keymap(self->virtual_keyboard,
+	                               WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
+	                               keymap_fd, keymap_size);
+
+	close(keymap_fd);
+
+	return 0;
+
+write_failure:
+	close(keymap_fd);
+fd_failure:
+	free(keymap_string);
+keymap_string_failure:
+	free(self->lookup_table);
+table_failure:
+	xkb_state_unref(self->state);
+state_failure:
+	xkb_keymap_unref(self->keymap);
+keymap_failure:
+	intset_destroy(&self->key_state);
+key_state_failure:
+	xkb_context_unref(self->context);
+	return -1;
+}
+
+void keyboard_destroy(struct keyboard* self)
+{
+	free(self->lookup_table);
+	xkb_state_unref(self->state);
+	xkb_keymap_unref(self->keymap);
+	intset_destroy(&self->key_state);
+	xkb_context_unref(self->context);
+}
+
+struct table_entry* keyboard_find_symbol(const struct keyboard* self,
+                                         xkb_keysym_t symbol)
+{
+	struct table_entry cmp = { .symbol = symbol };
+
+	struct table_entry* entry =
+		bsearch(&cmp, self->lookup_table, self->lookup_table_length,
+		        sizeof(*self->lookup_table), compare_symbols2);
+
+	if (!entry)
+		return NULL;
+
+	while (entry != self->lookup_table && (entry - 1)->symbol == symbol)
+		--entry;
+
+	return entry;
+}
+
+static void keyboard_send_mods(struct keyboard* self)
+{
+	xkb_mod_mask_t depressed, latched, locked, group;
+
+	depressed = xkb_state_serialize_mods(self->state, XKB_STATE_MODS_DEPRESSED);
+	latched = xkb_state_serialize_mods(self->state, XKB_STATE_MODS_LATCHED);
+	locked = xkb_state_serialize_mods(self->state, XKB_STATE_MODS_LOCKED);
+	group = xkb_state_serialize_mods(self->state, XKB_STATE_MODS_EFFECTIVE);
+
+	zwp_virtual_keyboard_v1_modifiers(self->virtual_keyboard, depressed,
+	                                  latched, locked, group);
+}
+
+static void keyboard_apply_mods(struct keyboard* self, xkb_keycode_t code,
+                                bool is_pressed)
+{
+	enum xkb_state_component comp, compmask;
+
+	comp = xkb_state_update_key(self->state, code,
+	                            is_pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
+
+	compmask = XKB_STATE_MODS_DEPRESSED |
+	           XKB_STATE_MODS_LATCHED |
+	           XKB_STATE_MODS_LOCKED |
+	           XKB_STATE_MODS_EFFECTIVE;
+
+	if (!(comp & compmask))
+		return;
+
+	keyboard_send_mods(self);
+}
+
+static struct table_entry* match_level(struct keyboard* self,
+                                       struct table_entry* entry)
+{
+	xkb_keysym_t symbol = entry->symbol;
+
+	while (true) {
+		int level;
+
+		level = xkb_state_key_get_level(self->state, entry->code, 0);
+
+		if (entry->level == level)
+			return entry;
+
+		if (++entry >= &self->lookup_table[self->lookup_table_length] ||
+		    entry->symbol != symbol)
+			break;
+	}
+
+	return NULL;
+}
+
+static bool keyboard_symbol_is_mod(xkb_keysym_t symbol)
+{
+	switch (symbol) {
+	case XKB_KEY_Shift_L:
+	case XKB_KEY_Shift_R:
+	case XKB_KEY_Control_L:
+	case XKB_KEY_Caps_Lock:
+	case XKB_KEY_Shift_Lock:
+	case XKB_KEY_Meta_L:
+	case XKB_KEY_Meta_R:
+	case XKB_KEY_Alt_L:
+	case XKB_KEY_Alt_R:
+	case XKB_KEY_Super_L:
+	case XKB_KEY_Super_R:
+	case XKB_KEY_Hyper_L:
+	case XKB_KEY_Hyper_R:
+	case XKB_KEY_ISO_Level5_Shift:
+	case XKB_KEY_ISO_Level5_Lock:
+		return true;
+	}
+
+	return false;
+}
+
+static void send_key(struct keyboard* self, xkb_keycode_t code, bool is_pressed)
+{
+	uint32_t t = get_time_ms();
+	logprint(DEBUG, "Sending 0x%x with timestamp %d.", code, t);
+	zwp_virtual_keyboard_v1_key(self->virtual_keyboard, t, code - 8,
+	                            is_pressed ? WL_KEYBOARD_KEY_STATE_PRESSED
+	                                       : WL_KEYBOARD_KEY_STATE_RELEASED);
+}
+
+static void save_mods(struct keyboard* self, struct kb_mods* mods)
+{
+	mods->depressed = xkb_state_serialize_mods(self->state,
+			XKB_STATE_MODS_DEPRESSED);
+	mods->latched = xkb_state_serialize_mods(self->state,
+			XKB_STATE_MODS_LATCHED);
+	mods->locked = xkb_state_serialize_mods(self->state,
+			XKB_STATE_MODS_LOCKED);
+}
+
+static void restore_mods(struct keyboard* self, struct kb_mods* mods)
+{
+	xkb_state_update_mask(self->state, mods->depressed, mods->latched,
+			mods->locked, XKB_STATE_MODS_DEPRESSED,
+			XKB_STATE_MODS_LATCHED, XKB_STATE_MODS_LOCKED);
+}
+
+static void send_key_with_level(struct keyboard* self, xkb_keycode_t code,
+		bool is_pressed, int level)
+{
+	struct kb_mods save;
+	save_mods(self, &save);
+
+	xkb_mod_mask_t mods = 0;
+	xkb_keymap_key_get_mods_for_level(self->keymap, code, 0, level,
+			&mods, 1);
+	xkb_state_update_mask(self->state, mods, 0, 0, XKB_STATE_MODS_DEPRESSED,
+			XKB_STATE_MODS_LATCHED, XKB_STATE_MODS_LOCKED);
+	keyboard_send_mods(self);
+
+	logprint(DEBUG, "send key with level: old mods: %x, new mods: %x",
+			save.latched | save.locked | save.depressed, mods);
+
+	send_key(self, code, is_pressed);
+
+	restore_mods(self, &save);
+	keyboard_send_mods(self);
+}
+
+static bool update_key_state(struct keyboard* self, xkb_keycode_t code,
+		bool is_pressed)
+{
+	bool was_pressed = intset_is_set(&self->key_state, code);
+	if (was_pressed == is_pressed)
+		return false;
+
+	if (is_pressed)
+		intset_set(&self->key_state, code);
+	else
+		intset_clear(&self->key_state, code);
+
+	return true;
+}
+
+void keyboard_feed(struct keyboard* self, xkb_keysym_t symbol, bool is_pressed)
+{
+	struct table_entry* entry = keyboard_find_symbol(self, symbol);
+	if (!entry) {
+		char name[256];
+		logprint(ERROR, "Failed to look up keyboard symbol: %s",
+		          get_symbol_name(symbol, name, sizeof(name)));
+		return;
+	}
+
+	bool level_is_match = true;
+
+	if (!keyboard_symbol_is_mod(symbol)) {
+		struct table_entry* level_entry = match_level(self, entry);
+		if (level_entry)
+			entry = level_entry;
+		else
+			level_is_match = false;
+	}
+
+#ifndef NDEBUG
+	keyboard__dump_entry(self, entry);
+#endif
+
+	if (!update_key_state(self, entry->code, is_pressed))
+		return;
+
+	keyboard_apply_mods(self, entry->code, is_pressed);
+
+	if (level_is_match)
+		send_key(self, entry->code, is_pressed);
+	else
+		send_key_with_level(self, entry->code, is_pressed,
+				entry->level);
+}
+
+void keyboard_feed_code(struct keyboard* self, xkb_keycode_t code,
+		bool is_pressed)
+{
+	if (update_key_state(self, code, is_pressed)) {
+		keyboard_apply_mods(self, code, is_pressed);
+		send_key(self, code, is_pressed);
+	}
+}

--- a/src/remotedesktop/remotedesktop.c
+++ b/src/remotedesktop/remotedesktop.c
@@ -1,0 +1,330 @@
+#include "remotedesktop.h"
+
+#include <time.h>
+
+#include "config.h"
+#include "xdpw.h"
+
+static const char object_path[] = "/org/freedesktop/portal/desktop";
+static const char interface_name[] = "org.freedesktop.impl.portal.RemoteDesktop";
+
+static struct xdpw_session *get_session_from_handle(struct xdpw_state *state, char *session_handle) {
+	struct xdpw_session *sess;
+	wl_list_for_each_reverse(sess, &state->xdpw_sessions, link) {
+		if (strcmp(sess->session_handle, session_handle) == 0) {
+			return sess;
+		}
+	}
+	return NULL;
+}
+
+static int method_remotedesktop_create_session(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	char *request_handle, *session_handle, *app_id, *key;
+	struct xdpw_request *req;
+	struct xdpw_session *sess;
+
+	logprint(DEBUG, "remotedesktop: create session: method invoked");
+
+	ret = sd_bus_message_read(msg, "oos", &request_handle, &session_handle, &app_id);
+	if (ret < 0) {
+		return ret;
+	}
+
+	logprint(DEBUG, "remotedesktop: create session: request_handle: %s", request_handle);
+	logprint(DEBUG, "remotedesktop: create session: session_handle: %s", session_handle);
+	logprint(DEBUG, "remotedesktop: create session: app_id: %s", app_id);
+
+	ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
+		ret = sd_bus_message_read(msg, "s", &key);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (strcmp(key, "session_handle_token") == 0) {
+			char *token;
+			sd_bus_message_read(msg, "v", "s", &token);
+			logprint(DEBUG, "remotedesktop: create session: session handle token: %s", token);
+		} else {
+			logprint(WARN, "remotedesktop: create session: unknown option: %s", key);
+			sd_bus_message_skip(msg, "v");
+		}
+
+		ret = sd_bus_message_exit_container(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_exit_container(msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	req = xdpw_request_create(sd_bus_message_get_bus(msg), request_handle);
+	if (req == NULL) {
+		return -ENOMEM;
+	}
+
+	sess = xdpw_session_create(state, sd_bus_message_get_bus(msg), strdup(session_handle));
+	if (sess == NULL) {
+		return -ENOMEM;
+	}
+
+	ret = sd_bus_reply_method_return(msg, "ua{sv}", PORTAL_RESPONSE_SUCCESS, 0);
+	if (ret < 0) {
+		return ret;
+	}
+	return 0;
+}
+
+static int method_remotedesktop_select_devices(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	char *request_handle, *session_handle, *app_id, *key;
+	struct xdpw_session *sess;
+
+	logprint(DEBUG, "remotedesktop: select devices: method invoked");
+
+	ret = sd_bus_message_read(msg, "oos", &request_handle, &session_handle, &app_id);
+	if (ret < 0) {
+		return ret;
+	}
+
+	logprint(DEBUG, "remotedesktop: select devices: request_handle: %s", request_handle);
+	logprint(DEBUG, "remotedesktop: select devices: session_handle: %s", session_handle);
+	logprint(DEBUG, "remotedesktop: select devices: app_id: %s", app_id);
+
+	sess = get_session_from_handle(state, session_handle);
+	if (!sess) {
+		logprint(WARN, "remotedesktop: select devices: session not found");
+		return -1;
+	}
+	logprint(DEBUG, "remotedesktop: select devices: session found");
+
+	ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
+		ret = sd_bus_message_read(msg, "s", &key);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (strcmp(key, "types") == 0) {
+			// TODO: compare to allowed types
+		} else {
+			logprint(WARN, "remotedesktop: select devices: unknown option: %s", key);
+			sd_bus_message_skip(msg, "v");
+		}
+
+		ret = sd_bus_message_exit_container(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_exit_container(msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_reply_method_return(msg, "ua{sv}", PORTAL_RESPONSE_SUCCESS, 0);
+	if (ret < 0) {
+		return ret;
+	}
+	return 0;
+}
+
+static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	char *request_handle, *session_handle, *app_id, *parent_window, *key;
+	struct xdpw_session *sess;
+
+	logprint(DEBUG, "remotedesktop: start: method invoked");
+
+	ret = sd_bus_message_read(msg, "oos", &request_handle, &session_handle, &app_id);
+	if (ret < 0) {
+		return ret;
+	}
+
+	logprint(DEBUG, "remotedesktop: start: request_handle: %s", request_handle);
+	logprint(DEBUG, "remotedesktop: start: session_handle: %s", session_handle);
+	logprint(DEBUG, "remotedesktop: start: app_id: %s", app_id);
+
+	sess = get_session_from_handle(state, session_handle);
+	if (!sess) {
+		logprint(WARN, "remotedesktop: start: session not found");
+		return -1;
+	}
+	logprint(DEBUG, "remotedesktop: dbus: start: session found");
+
+	ret = sd_bus_message_read(msg, "s", &parent_window);
+	if (ret < 0) {
+		return ret;
+	}
+	logprint(DEBUG, "remotedesktop: start: parent window: %s", parent_window);
+
+	ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
+		ret = sd_bus_message_read(msg, "s", &key);
+		if (ret < 0) {
+			return ret;
+		}
+
+		logprint(WARN, "remotedesktop: start: unknown option: %s", key);
+		sd_bus_message_skip(msg, "v");
+
+		ret = sd_bus_message_exit_container(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_exit_container(msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_reply_method_return(msg, "ua{sv}", PORTAL_RESPONSE_SUCCESS,
+		1, "devices", "u", 0);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int method_remotedesktop_notify_pointer_motion(sd_bus_message *msg,
+		void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_pointer_motion called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_pointer_motion_absolute(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_pointer_motion_absolute called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_pointer_button(sd_bus_message *msg,
+		void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_pointer_button called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_pointer_axis(sd_bus_message *msg,
+		void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_pointer_axis called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_pointer_axis_discrete(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_pointer_axis_discrete called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_keyboard_keycode(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_keyboard_keycode called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_keyboard_keysym(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_keyboard_keysim called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_touch_down(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+
+	logprint(ERROR, "remotedesktop: notify_touch_down called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_touch_motion(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_touch_motion called, but not supported!");
+	return -1;
+}
+
+static int method_remotedesktop_notify_touch_up(
+		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
+	logprint(ERROR, "remotedesktop: notify_touch_up called, but not supported!");
+	return -1;
+}
+
+static const sd_bus_vtable remotedesktop_vtable[] = {
+	SD_BUS_VTABLE_START(0),
+	SD_BUS_METHOD("CreateSession", "oosa{sv}", "ua{sv}",
+		method_remotedesktop_create_session, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("SelectDevices", "oosa{sv}", "ua{sv}",
+		method_remotedesktop_select_devices, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("Start", "oossa{sv}", "ua{sv}",
+		method_remotedesktop_start, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyPointerMotion", "oa{sv}dd", NULL,
+		method_remotedesktop_notify_pointer_motion, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyPointerMotionAbsolute", "oa{sv}udd", NULL,
+		method_remotedesktop_notify_pointer_motion_absolute, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyPointerButton", "oa{sv}iu", NULL,
+		method_remotedesktop_notify_pointer_button, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyPointerAxis", "oa{sv}dd", NULL,
+		method_remotedesktop_notify_pointer_axis, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyPointerAxisDiscrete", "oa{sv}ui", NULL,
+		method_remotedesktop_notify_pointer_axis_discrete, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyKeyboardKeycode", "oa{sv}iu", NULL,
+		method_remotedesktop_notify_keyboard_keycode, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyKeyboardKeysym", "oa{sv}iu", NULL,
+		method_remotedesktop_notify_keyboard_keysym, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyTouchDown", "oa{sv}uudd", NULL,
+		method_remotedesktop_notify_touch_down, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyTouchMotion", "oa{sv}uudd", NULL,
+		method_remotedesktop_notify_touch_motion, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("NotifyTouchUp", "oa{sv}u", NULL,
+		method_remotedesktop_notify_touch_up, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_PROPERTY("AvailableDeviceTypes", "u", NULL,
+		offsetof(struct xdpw_state, remotedesktop_available_device_types),
+		SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("version", "u", NULL,
+		offsetof(struct xdpw_state, remotedesktop_version),
+		SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_VTABLE_END
+};
+
+int xdpw_remotedesktop_init(struct xdpw_state *state) {
+	sd_bus_slot *slot = NULL;
+
+	state->remotedesktop = (struct xdpw_remotedesktop_context) { 0 };
+	state->remotedesktop.state = state;
+
+	return sd_bus_add_object_vtable(state->bus, &slot, object_path,
+		interface_name, remotedesktop_vtable, state);
+}
+
+void xdpw_remotedesktop_destroy(struct xdpw_remotedesktop_session_data *data) {
+	logprint(DEBUG, "remotedesktop: destroy called.");
+}

--- a/src/remotedesktop/remotedesktop.c
+++ b/src/remotedesktop/remotedesktop.c
@@ -2,8 +2,9 @@
 
 #include <time.h>
 
-#include "virtual_input.h"
 #include "config.h"
+#include "virtual_input.h"
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 #include "xdpw.h"
 
 static const char object_path[] = "/org/freedesktop/portal/desktop";
@@ -212,11 +213,28 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 		logprint(WARN, "remotedesktop: start: session not found");
 		return -1;
 	}
-	logprint(DEBUG, "remotedesktop: dbus: start: session found");
+	logprint(DEBUG, "remotedesktop: start: session found");
 
 	remote = &sess->remotedesktop_data;
 	remote->virtual_pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(
 		state->remotedesktop.virtual_pointer_manager, NULL);
+
+	// TODO: make this user configureable
+	struct xkb_rule_names rule_names = {
+		.rules = "evdev",
+		.layout = "us",
+		.model = "pc105",
+		.variant = "",
+		.options = "",
+	};
+	logprint(DEBUG, "Creating virtual keyboard with manager 0x%x",
+			state->remotedesktop.virtual_keyboard_manager);
+	remote->keyboard.virtual_keyboard = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(
+			state->remotedesktop.virtual_keyboard_manager, state->remotedesktop.seat);
+	ret = keyboard_init(&remote->keyboard, &rule_names);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ret = sd_bus_message_read(msg, "s", &parent_window);
 	if (ret < 0) {
@@ -472,14 +490,68 @@ static int method_remotedesktop_notify_pointer_axis_discrete(
 
 static int method_remotedesktop_notify_keyboard_keycode(
 		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_keyboard_keycode called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	int32_t keycode;
+	uint32_t keystate;
+
+	logprint(TRACE, "remotedesktop: nkkc: method invoked");
+	ret = get_session_from_sd_bus(msg, state, KEYBOARD, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "i", &keycode);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "u", &keystate);
+	if (ret < 0) {
+		return ret;
+	}
+	logprint(DEBUG, "remotedesktop: received code %x, state %u", keycode, keystate);
+	// The remotedesktop keycodes are evdev keycodes. They are converted to xkb keycodes by a
+	// fixed offset of 8.
+	keyboard_feed_code(&sess->remotedesktop_data.keyboard, keycode + 8, keystate == 1);
+	return 0;
 }
 
 static int method_remotedesktop_notify_keyboard_keysym(
 		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_keyboard_keysim called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	int32_t keysym;
+	uint32_t keystate;
+
+	logprint(TRACE, "remotedesktop: nkks: method invoked");
+	ret = get_session_from_sd_bus(msg, state, KEYBOARD, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "i", &keysym);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "u", &keystate);
+	if (ret < 0) {
+		return ret;
+	}
+	logprint(DEBUG, "remotedesktop: received symbol %x, state %u", keysym, keystate);
+	keyboard_feed(&sess->remotedesktop_data.keyboard, (xkb_keysym_t)keysym, keystate == 1);
+	return 0;
 }
 
 static int method_remotedesktop_notify_touch_down(
@@ -564,5 +636,10 @@ void xdpw_remotedesktop_destroy(struct xdpw_remotedesktop_session_data *data) {
 	if (data->virtual_pointer) {
 		zwlr_virtual_pointer_v1_destroy(data->virtual_pointer);
 		data->virtual_pointer = NULL;
+	}
+	if (data->keyboard.virtual_keyboard) {
+		zwp_virtual_keyboard_v1_destroy(data->keyboard.virtual_keyboard);
+		data->keyboard.virtual_keyboard = NULL;
+		keyboard_destroy(&data->keyboard);
 	}
 }

--- a/src/remotedesktop/remotedesktop.c
+++ b/src/remotedesktop/remotedesktop.c
@@ -1,8 +1,11 @@
 #include "remotedesktop.h"
 
+#include <spa/utils/result.h>
 #include <time.h>
 
 #include "config.h"
+#include "remotedesktop_common.h"
+#include "screencast.h"
 #include "virtual_input.h"
 #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 #include "xdpw.h"
@@ -214,6 +217,25 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 		return -1;
 	}
 	logprint(DEBUG, "remotedesktop: start: session found");
+	struct xdpw_screencast_instance *cast = sess->screencast_data.screencast_instance;
+	logprint(DEBUG, "remotedesktop: screencast instance %x", cast);
+
+	if (cast) {
+		logprint(DEBUG, "remotedesktop: starting screencast");
+		if (!cast->initialized) {
+			ret = xdpw_screencast_start(cast);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+		while (cast->node_id == SPA_ID_INVALID) {
+			int ret = pw_loop_iterate(state->pw_loop, 0);
+			if (ret < 0) {
+				logprint(ERROR, "pipewire_loop_iterate failed: %s", spa_strerror(ret));
+				return ret;
+			}
+		}
+	}
 
 	remote = &sess->remotedesktop_data;
 	remote->virtual_pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(
@@ -268,11 +290,109 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 		return ret;
 	}
 
-	ret = sd_bus_reply_method_return(msg, "ua{sv}", PORTAL_RESPONSE_SUCCESS,
-		1, "devices", "u", remote->devices);
+	sd_bus_message *reply = NULL;
+	ret = sd_bus_message_new_method_return(msg, &reply);
 	if (ret < 0) {
 		return ret;
 	}
+	ret = sd_bus_message_append(reply, "u", PORTAL_RESPONSE_SUCCESS);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_append(reply, "{sv}",
+		"devices", "u", remote->devices);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_open_container(reply, 'e', "sv");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_append(reply, "s", "streams");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'v', "a(ua{sv})");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_open_container(reply, 'a', "(ua{sv})");
+	if (ret < 0) {
+		return ret;
+	}
+	if (cast) {
+		ret = sd_bus_message_open_container(reply, 'r', "ua{sv}");
+		if (ret < 0) {
+			return ret;
+		}
+		ret = sd_bus_message_append(reply, "u", cast->node_id);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = sd_bus_message_open_container(reply, 'a', "{sv}");
+		if (ret < 0) {
+			return ret;
+		}
+		if (cast->target->output->xdg_output) {
+			ret = sd_bus_message_append(reply, "{sv}",
+				"position", "(ii)", cast->target->output->x, cast->target->output->y);
+			if (ret < 0) {
+				return ret;
+			}
+			ret = sd_bus_message_append(reply, "{sv}",
+				"size", "(ii)", cast->target->output->width, cast->target->output->height);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+		ret = sd_bus_message_append(reply, "{sv}", "source_type", "u", MONITOR);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = sd_bus_message_close_container(reply);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = sd_bus_message_close_container(reply);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_append(reply, "{sv}",
+		"devices", "u", remote->devices);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_close_container(reply);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_send(NULL, reply, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+	sd_bus_message_unref(reply);
 
 	return 0;
 }

--- a/src/remotedesktop/remotedesktop.c
+++ b/src/remotedesktop/remotedesktop.c
@@ -2,6 +2,7 @@
 
 #include <time.h>
 
+#include "virtual_input.h"
 #include "config.h"
 #include "xdpw.h"
 
@@ -16,6 +17,30 @@ static struct xdpw_session *get_session_from_handle(struct xdpw_state *state, ch
 		}
 	}
 	return NULL;
+}
+
+static int get_session_from_sd_bus(sd_bus_message *msg, struct xdpw_state *state,
+		uint32_t device_type, struct xdpw_session **sess) {
+	char *session_handle;
+	int ret = sd_bus_message_read(msg, "o", &session_handle);
+	if (ret < 0) {
+		return ret;
+	}
+	logprint(TRACE, "remotedesktop: session_handle: %s", session_handle);
+
+	*sess = get_session_from_handle(state, session_handle);
+	if (!*sess) {
+		logprint(WARN, "remotedesktop: session not found");
+		return -1;
+	}
+	logprint(TRACE, "remotedesktop: session found");
+
+	if (!((*sess)->remotedesktop_data.devices & device_type)) {
+		logprint(ERROR, "remotedesktop: remote tried to control forbidden device type %u!",
+			device_type);
+		return -2;
+	}
+	return 0;
 }
 
 static int method_remotedesktop_create_session(sd_bus_message *msg, void *data,
@@ -189,6 +214,10 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 	}
 	logprint(DEBUG, "remotedesktop: dbus: start: session found");
 
+	remote = &sess->remotedesktop_data;
+	remote->virtual_pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(
+		state->remotedesktop.virtual_pointer_manager, NULL);
+
 	ret = sd_bus_message_read(msg, "s", &parent_window);
 	if (ret < 0) {
 		return ret;
@@ -221,7 +250,6 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 		return ret;
 	}
 
-	remote = &sess->remotedesktop_data;
 	ret = sd_bus_reply_method_return(msg, "ua{sv}", PORTAL_RESPONSE_SUCCESS,
 		1, "devices", "u", remote->devices);
 	if (ret < 0) {
@@ -233,32 +261,213 @@ static int method_remotedesktop_start(sd_bus_message *msg, void *data, sd_bus_er
 
 static int method_remotedesktop_notify_pointer_motion(sd_bus_message *msg,
 		void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_pointer_motion called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	double dx = 0, dy = 0;
+
+	logprint(TRACE, "remotedesktop: npm: method invoked");
+	ret = get_session_from_sd_bus(msg, state, POINTER, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "dd", &dx, &dy);
+	if (ret < 0) {
+		return ret;
+	}
+
+	zwlr_virtual_pointer_v1_motion(sess->remotedesktop_data.virtual_pointer, get_time_ms(),
+		wl_fixed_from_double(dx), wl_fixed_from_double(dy));
+	zwlr_virtual_pointer_v1_frame(sess->remotedesktop_data.virtual_pointer);
+
+	return 0;
 }
 
 static int method_remotedesktop_notify_pointer_motion_absolute(
 		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_pointer_motion_absolute called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	double x = 0, y = 0;
+
+	logprint(TRACE, "remotedesktop: npma: method invoked");
+	ret = get_session_from_sd_bus(msg, state, POINTER, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_skip(msg, "u");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "dd", &x, &y);
+	if (ret < 0) {
+		return ret;
+	}
+
+	struct xdpw_wlr_output *output = sess->screencast_data.screencast_instance->target->output;
+	zwlr_virtual_pointer_v1_motion_absolute(sess->remotedesktop_data.virtual_pointer,
+		get_time_ms(), x, y, output->width, output->height);
+	zwlr_virtual_pointer_v1_frame(sess->remotedesktop_data.virtual_pointer);
+
+	return 0;
 }
 
 static int method_remotedesktop_notify_pointer_button(sd_bus_message *msg,
 		void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_pointer_button called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	int32_t button;
+	uint32_t btn_state;
+
+	logprint(DEBUG, "remotedesktop: npb: method invoked");
+	ret = get_session_from_sd_bus(msg, state, POINTER, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "i", &button);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "u", &btn_state);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (btn_state == WL_POINTER_BUTTON_STATE_PRESSED) {
+		if (sess->remotedesktop_data.pressed_buttons & 1<<button) {
+			logprint(WARN, "remotedesktop: npb: pointer already pressed, ignoring");
+			return 0;
+		}
+		sess->remotedesktop_data.pressed_buttons |= 1<<button;
+	} else {
+		sess->remotedesktop_data.pressed_buttons &= ~(1<<button);
+	}
+	zwlr_virtual_pointer_v1_button(sess->remotedesktop_data.virtual_pointer, get_time_ms(),
+		button, btn_state);
+	zwlr_virtual_pointer_v1_frame(sess->remotedesktop_data.virtual_pointer);
+	return 0;
 }
 
 static int method_remotedesktop_notify_pointer_axis(sd_bus_message *msg,
 		void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_pointer_axis called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0, finish = 0;
+	char *key;
+	struct xdpw_session *sess;
+	double dx = 0, dy = 0;
+
+	logprint(TRACE, "remotedesktop: npa: method invoked");
+	ret = get_session_from_sd_bus(msg, state, POINTER, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
+		ret = sd_bus_message_read(msg, "s", &key);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (strcmp(key, "finish") == 0) {
+			sd_bus_message_read(msg, "v", "b", &finish);
+			logprint(DEBUG, "remotedesktop: npa: finish: %d", finish);
+		} else {
+			logprint(WARN, "remotedesktop: npa: unknown option: %s", key);
+			sd_bus_message_skip(msg, "v");
+		}
+
+		ret = sd_bus_message_exit_container(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_exit_container(msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_read(msg, "dd", &dx, &dy);
+	if (ret < 0) {
+		return ret;
+	}
+
+	struct zwlr_virtual_pointer_v1 *pointer = sess->remotedesktop_data.virtual_pointer;
+	uint32_t t = get_time_ms();
+
+	zwlr_virtual_pointer_v1_axis_source(pointer, WL_POINTER_AXIS_SOURCE_CONTINUOUS);
+	zwlr_virtual_pointer_v1_axis(pointer, t, WL_POINTER_AXIS_VERTICAL_SCROLL,
+			wl_fixed_from_double(dy));
+	zwlr_virtual_pointer_v1_axis(pointer, t, WL_POINTER_AXIS_HORIZONTAL_SCROLL,
+			wl_fixed_from_double(dx));
+
+	if (finish) {
+		zwlr_virtual_pointer_v1_axis_stop(pointer, t, WL_POINTER_AXIS_VERTICAL_SCROLL);
+		zwlr_virtual_pointer_v1_axis_stop(pointer, t, WL_POINTER_AXIS_HORIZONTAL_SCROLL);
+	}
+
+	zwlr_virtual_pointer_v1_frame(pointer);
+	return 0;
 }
 
 static int method_remotedesktop_notify_pointer_axis_discrete(
 		sd_bus_message *msg, void *data, sd_bus_error *ret_error) {
-	logprint(ERROR, "remotedesktop: notify_pointer_axis_discrete called, but not supported!");
-	return -1;
+	struct xdpw_state *state = data;
+
+	int ret = 0;
+	struct xdpw_session *sess;
+	uint32_t axis;
+	int32_t steps;
+
+	logprint(DEBUG, "remotedesktop: npad: method invoked");
+	ret = get_session_from_sd_bus(msg, state, POINTER, &sess);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sd_bus_message_skip(msg, "a{sv}");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "u", &axis);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = sd_bus_message_read(msg, "i", &steps);
+	if (ret < 0) {
+		return ret;
+	}
+
+	zwlr_virtual_pointer_v1_axis_discrete(sess->remotedesktop_data.virtual_pointer,
+			get_time_ms(), axis, wl_fixed_from_double(0.1), steps);
+	zwlr_virtual_pointer_v1_frame(sess->remotedesktop_data.virtual_pointer);
+	return 0;
 }
 
 static int method_remotedesktop_notify_keyboard_keycode(
@@ -335,10 +544,25 @@ int xdpw_remotedesktop_init(struct xdpw_state *state) {
 	state->remotedesktop = (struct xdpw_remotedesktop_context) { 0 };
 	state->remotedesktop.state = state;
 
+	int err;
+	err = xdpw_virtual_input_init(state);
+	if (err) {
+		goto fail_virtual_input;
+	}
+
 	return sd_bus_add_object_vtable(state->bus, &slot, object_path,
 		interface_name, remotedesktop_vtable, state);
+
+fail_virtual_input:
+	xdpw_virtual_input_finish(&state->remotedesktop);
+
+	return err;
 }
 
 void xdpw_remotedesktop_destroy(struct xdpw_remotedesktop_session_data *data) {
 	logprint(DEBUG, "remotedesktop: destroy called.");
+	if (data->virtual_pointer) {
+		zwlr_virtual_pointer_v1_destroy(data->virtual_pointer);
+		data->virtual_pointer = NULL;
+	}
 }

--- a/src/remotedesktop/remotedesktop_common.c
+++ b/src/remotedesktop/remotedesktop_common.c
@@ -1,0 +1,10 @@
+#include <time.h>
+
+#include "remotedesktop_common.h"
+
+uint32_t get_time_ms() {
+	struct timespec t;
+	clock_gettime(CLOCK_MONOTONIC, &t);
+	return t.tv_sec * 1e3 + t.tv_nsec * 1e-6;
+}
+

--- a/src/remotedesktop/virtual_input.c
+++ b/src/remotedesktop/virtual_input.c
@@ -1,0 +1,69 @@
+#include "virtual_input.h"
+
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+
+#include "remotedesktop.h"
+#include "xdpw.h"
+#include "logger.h"
+
+static void wlr_registry_handle_add(void *data, struct wl_registry *reg,
+		uint32_t id, const char *interface, uint32_t ver) {
+	struct xdpw_remotedesktop_context *ctx = data;
+
+	logprint(DEBUG, "wlroots: interface to register %s  (Version: %u)",
+		interface, ver);
+
+	if (!strcmp(interface, zwlr_virtual_pointer_manager_v1_interface.name)) {
+		uint32_t version = ver;
+		if (VIRTUAL_POINTER_VERSION < ver) {
+			version = VIRTUAL_POINTER_VERSION;
+		} else if (ver < VIRTUAL_POINTER_VERSION_MIN) {
+			version = VIRTUAL_POINTER_VERSION_MIN;
+		}
+		logprint(DEBUG,
+			"wlroots: |-- registered to interface %s (Version %u)",
+			interface, version);
+		ctx->virtual_pointer_manager = wl_registry_bind(reg, id,
+			&zwlr_virtual_pointer_manager_v1_interface, version);
+	}
+}
+
+static void wlr_registry_handle_remove(void *data, struct wl_registry *reg,
+		uint32_t id) {
+	// TODO: handle seat removal?
+}
+
+static const struct wl_registry_listener wlr_registry_listener = {
+	.global = wlr_registry_handle_add,
+	.global_remove = wlr_registry_handle_remove,
+};
+
+int xdpw_virtual_input_init(struct xdpw_state *state) {
+	struct xdpw_remotedesktop_context *ctx = &state->remotedesktop;
+
+	// retrieve registry
+	ctx->registry = wl_display_get_registry(state->wl_display);
+	wl_registry_add_listener(ctx->registry, &wlr_registry_listener, ctx);
+
+	if (wl_display_roundtrip(state->wl_display) == -1) {
+		logprint(ERROR, "wayland: wl_display_rondtrip failed.");
+		return -1;
+	}
+
+	logprint(DEBUG, "wayland: registry listeners run");
+
+	// make sure our wlroots supports virtual-pointer protocol
+	if (!ctx->virtual_pointer_manager) {
+		logprint(ERROR, "Compositor doesn't support %s!",
+			zwlr_virtual_pointer_manager_v1_interface.name);
+		return -1;
+	}
+
+	return 0;
+}
+
+void xdpw_virtual_input_finish(struct xdpw_remotedesktop_context *ctx) {
+	if (ctx->virtual_pointer_manager) {
+		zwlr_virtual_pointer_manager_v1_destroy(ctx->virtual_pointer_manager);
+	}
+}

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -13,6 +13,7 @@
 #include <libdrm/drm_fourcc.h>
 
 #include "screencast.h"
+#include "shm_util.h"
 #include "wlr_screencast.h"
 #include "xdpw.h"
 #include "logger.h"

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -230,7 +230,7 @@ bool setup_target(struct xdpw_screencast_context *ctx, struct xdpw_session *sess
 
 }
 
-static int start_screencast(struct xdpw_screencast_instance *cast) {
+int xdpw_screencast_start(struct xdpw_screencast_instance *cast) {
 	int ret;
 	ret = xdpw_wlr_session_init(cast);
 	if (ret < 0) {
@@ -590,7 +590,7 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 	}
 
 	if (!cast->initialized) {
-		ret = start_screencast(cast);
+		ret = xdpw_screencast_start(cast);
 	}
 	if (ret < 0) {
 		return ret;

--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
+Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;
 UseIn=wlroots;sway;Wayfire;river;phosh;Hyprland;


### PR DESCRIPTION
Based on #263

Implements pointer and keyboard support, with most of the keyboard code copied from Wayvnc.

My usecase ist the kdeconnect remote input, so that's how it is tested. Sometimes sway pointer input seems to be completely broken after a while, see ce01c224 for a try to fix that (not sure whether this is the right approach).
Keyboard input works mostly but somehow capital letters don't, not sure whether this is a kdeconnect bug or in this implementation.

It also implements ScreenCast via the RemoteDesktop protocol, so Zoom screen sharing works again.