### PR TITLE
pipewire: use a wrapper function for timer callback

### DIFF
--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -526,6 +526,10 @@ static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer
 	buffer->user_data = NULL;
 }
 
+static void xdpw_wlr_frame_capture_cb(void *data) {
+	xdpw_wlr_frame_capture(data);
+}
+
 static void pwr_handle_stream_on_process(void *data) {
 	struct xdpw_screencast_instance *cast = data;
 
@@ -549,8 +553,7 @@ static void pwr_handle_stream_on_process(void *data) {
 	if (cast->seq > 0) {
 		uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
 		if (delay_ns > 0) {
-			xdpw_add_timer(cast->ctx->state, delay_ns,
-				(xdpw_event_loop_timer_func_t) xdpw_wlr_frame_capture, cast);
+			xdpw_add_timer(cast->ctx->state, delay_ns, xdpw_wlr_frame_capture_cb, cast);
 			return;
 		}
 	}


### PR DESCRIPTION
Fixes undefined behavior detected by UBsan:
runtime error: call to function xdpw_wlr_frame_capture through pointer to incorrect function type 'void (*)(void *)'