### PR TITLE
Fix wlr_screencopy regression

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -73,6 +73,7 @@ struct xdpw_buffer {
 	uint32_t height;
 	uint32_t format;
 	int plane_count;
+	uint64_t modifier;
 
 	int fd[GBM_MAX_PLANES];
 	uint32_t size[GBM_MAX_PLANES];

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -168,11 +168,11 @@ struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 			return NULL;
 		}
 
+		buffer->modifier = gbm_bo_get_modifier(buffer->bo);
 		for (int plane = 0; plane < buffer->plane_count; plane++) {
 			buffer->size[plane] = 0;
 			buffer->stride[plane] = gbm_bo_get_stride_for_plane(buffer->bo, plane);
 			buffer->offset[plane] = gbm_bo_get_offset(buffer->bo, plane);
-			uint64_t mod = gbm_bo_get_modifier(buffer->bo);
 			buffer->fd[plane] = gbm_bo_get_fd_for_plane(buffer->bo, plane);
 
 			if (buffer->fd[plane] < 0) {
@@ -183,7 +183,8 @@ struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 			}
 
 			zwp_linux_buffer_params_v1_add(params, buffer->fd[plane], plane,
-				buffer->offset[plane], buffer->stride[plane], mod >> 32, mod & 0xffffffff);
+				buffer->offset[plane], buffer->stride[plane], buffer->modifier >> 32,
+				buffer->modifier & 0xffffffff);
 		}
 		buffer->buffer = zwp_linux_buffer_params_v1_create_immed(params,
 			buffer->width, buffer->height,


### PR DESCRIPTION
The new xdpw buffer constraint system did not account for wlr_screencopy sending the same constraints on every single frame.

In wlr_screencopy, check if a buffer matches the current constraints and only complain if it does not. This is the original behavior, albeit checking the allocated buffer details rather than focusing on the configured pipewire details.

(This is unfortunately not portable to ext_image_copy without sorting out dmabuf device comparison.)

Fixes: https://github.com/emersion/xdg-desktop-portal-wlr/pull/326#issuecomment-2948355389