### PR TITLE
Add rofi chooser

### DIFF
--- a/src/screencast/chooser.c
+++ b/src/screencast/chooser.c
@@ -162,6 +162,7 @@ static struct xdpw_wlr_output *wlr_output_chooser_default(struct wl_list *output
 		{XDPW_CHOOSER_SIMPLE, "slurp -f %o -or"},
 		{XDPW_CHOOSER_DMENU, "wmenu -p 'Select the monitor to share:'"},
 		{XDPW_CHOOSER_DMENU, "wofi -d -n --prompt='Select the monitor to share:'"},
+		{XDPW_CHOOSER_DMENU, "rofi -dmenu -p 'Select the monitor to share:'"},
 		{XDPW_CHOOSER_DMENU, "bemenu --prompt='Select the monitor to share:'"},
 	};
 

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -64,7 +64,7 @@ These options need to be placed under the **[screencast]** section.
 
 	The supported types are:
 	- default: xdpw will try to use the first chooser found in the list of hardcoded choosers
-	  (slurp, wmenu, wofi, bemenu) and will fallback to an arbitrary output if none of those were found.
+	  (slurp, wmenu, wofi, rofi, bemenu) and will fallback to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
 	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details


### PR DESCRIPTION
Hello!

It seems that [fork of rofi with Wayland support](https://github.com/lbonn/rofi) is still a popular chooser to the point that official Sway spin on Fedora is using it as default. Would you consider adding it to supported choosers as well? 