### PR TITLE
Do nothing if capture frame is already pending

### DIFF
--- a/src/screencast/ext_image_copy.c
+++ b/src/screencast/ext_image_copy.c
@@ -310,6 +310,10 @@ void xdpw_ext_ic_frame_capture(struct xdpw_screencast_instance *cast) {
 		logprint(ERROR, "ext: started frame without buffer");
 		return;
 	}
+	if (cast->ext_session.frame) {
+		logprint(DEBUG, "ext: frame already requested");
+		return;
+	}
 
 	ext_register_frame_cb(cast);
 }


### PR DESCRIPTION
If we already have a frame pending when told to start capture, do nothing and wait for the coming frame events. Asking for another frame is a protocol error.

Seen when rapidly resizing a window during toplevel capture.