### PR TITLE
Throttle fps from start of frame capture

### DIFF
--- a/src/screencast/ext_image_copy.c
+++ b/src/screencast/ext_image_copy.c
@@ -24,7 +24,6 @@
 #include "pipewire_screencast.h"
 #include "xdpw.h"
 #include "logger.h"
-#include "fps_limit.h"
 
 static void ext_session_buffer_size(void *data,
 		struct ext_image_copy_capture_session_v1 *ext_image_copy_capture_session_v1,
@@ -202,7 +201,6 @@ static void ext_frame_presentation_time(void *data,
 static void ext_frame_ready(void *data,
 		struct ext_image_copy_capture_frame_v1 *ext_image_copy_capture_frame_v1) {
 	struct xdpw_screencast_instance *cast = data;
-	fps_limit_measure_start(&cast->fps_limit, cast->framerate);
 
 	logprint(TRACE, "ext: ready event handler");
 

--- a/src/screencast/fps_limit.c
+++ b/src/screencast/fps_limit.c
@@ -19,12 +19,9 @@ void fps_limit_measure_start(struct fps_limit_state *state, double max_fps) {
 }
 
 uint64_t fps_limit_measure_end(struct fps_limit_state *state, double max_fps) {
-	if (max_fps <= 0.0) {
+	if (max_fps <= 0.0 || timespec_is_zero(&state->frame_last_time)) {
 		return 0;
 	}
-
-	// `fps_limit_measure_start` was not called?
-	assert(!timespec_is_zero(&state->frame_last_time));
 
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -567,10 +567,6 @@ static void pwr_handle_stream_remove_buffer(void *data, struct pw_buffer *buffer
 	buffer->user_data = NULL;
 }
 
-static void xdpw_wlr_frame_capture_cb(void *data) {
-	xdpw_wlr_frame_capture(data);
-}
-
 static void pwr_handle_stream_on_process(void *data) {
 	struct xdpw_screencast_instance *cast = data;
 
@@ -590,13 +586,6 @@ static void pwr_handle_stream_on_process(void *data) {
 	if (!cast->current_frame.pw_buffer) {
 		logprint(WARN, "pipewire: unable to export buffer");
 		return;
-	}
-	if (cast->seq > 0) {
-		uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
-		if (delay_ns > 0) {
-			xdpw_add_timer(cast->ctx->state, delay_ns, xdpw_wlr_frame_capture_cb, cast);
-			return;
-		}
 	}
 	xdpw_wlr_frame_capture(cast);
 }

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -41,14 +41,12 @@ static void wlr_frame_capture_timer(void *data) {
 }
 
 void xdpw_wlr_frame_capture(struct xdpw_screencast_instance *cast) {
-	if (cast->seq > 0) {
-		uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
-		if (delay_ns > 0) {
-			xdpw_add_timer(cast->ctx->state, delay_ns, wlr_frame_capture_timer, cast);
-			return;
-		}
+	uint64_t delay_ns = fps_limit_measure_end(&cast->fps_limit, cast->framerate);
+	if (delay_ns > 0) {
+		xdpw_add_timer(cast->ctx->state, delay_ns, wlr_frame_capture_timer, cast);
+	} else {
+		wlr_frame_capture_start(cast);
 	}
-	wlr_frame_capture_start(cast);
 }
 
 void xdpw_wlr_session_close(struct xdpw_screencast_instance *cast) {

--- a/src/screencast/wlr_screencopy.c
+++ b/src/screencast/wlr_screencopy.c
@@ -22,7 +22,6 @@
 #include "pipewire_screencast.h"
 #include "xdpw.h"
 #include "logger.h"
-#include "fps_limit.h"
 
 static void wlr_frame_finish(struct xdpw_screencast_instance *cast) {
 	if (!cast->wlr_session.wlr_frame) {
@@ -159,8 +158,6 @@ static void wlr_frame_buffer_done(void *data,
 
 	zwlr_screencopy_frame_v1_copy_with_damage(frame, cast->current_frame.xdpw_buffer->buffer);
 	logprint(TRACE, "wlroots: frame copied");
-
-	fps_limit_measure_start(&cast->fps_limit, cast->framerate);
 }
 
 static void wlr_frame_flags(void *data, struct zwlr_screencopy_frame_v1 *frame,


### PR DESCRIPTION
The fps limit logic was throttling the time between the completion of one recorded frame and the request for the next frame. This means that the time it takes to request the frame, including if the compositor stalls for a frame to be available, is not measured as part of the current frame rate.

Measure from start of frame till start of frame.

(I didn't run into a particular issue here including in test, just seemed wrong.)