### PR TITLE
Refcount gbm device and only open if it changed

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -48,6 +48,12 @@ struct xdpw_chooser {
 	const char *cmd;
 };
 
+struct xdpw_gbm_device {
+	struct gbm_device *gbm;
+	drmDevice *dmabuf_device;
+	int refcnt;
+};
+
 struct xdpw_frame_damage {
 	uint32_t x;
 	uint32_t y;
@@ -125,7 +131,7 @@ struct xdpw_screencast_context {
 	struct wl_array format_modifier_pairs;
 
 	// gbm
-	struct gbm_device *gbm;
+	struct xdpw_gbm_device *gbm;
 
 	// sessions
 	struct wl_list screencast_instances;
@@ -160,12 +166,14 @@ struct xdpw_shm_format {
 	uint32_t stride;
 };
 
+
 struct xdpw_buffer_constraints {
 	struct wl_array dmabuf_format_modifier_pairs;
 	struct wl_array shm_formats;
 	uint32_t width, height;
 	bool dirty;
-	struct gbm_device *gbm;
+	drmDevice *dmabuf_device;
+	struct xdpw_gbm_device *gbm;
 };
 
 struct xdpw_screencast_ext_session {
@@ -239,7 +247,10 @@ struct xdpw_wlr_output {
 };
 
 void randname(char *buf);
-struct gbm_device *xdpw_gbm_device_create(drmDevice *device);
+struct xdpw_gbm_device *xdpw_gbm_device_create(drmDevice *device);
+struct xdpw_gbm_device *xdpw_gbm_device_ref(struct xdpw_gbm_device *gbm);
+void xdpw_gbm_device_unref(struct xdpw_gbm_device *gbm);
+struct gbm_device *xdpw_get_gbm(struct xdpw_screencast_instance *cast);
 struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 	enum buffer_type buffer_type);
 void xdpw_buffer_destroy(struct xdpw_buffer *buffer);

--- a/src/screencast/ext_image_copy.c
+++ b/src/screencast/ext_image_copy.c
@@ -85,11 +85,16 @@ static void ext_session_dmabuf_device(void *data,
 		return;
 	}
 
-	cast->pending_constraints.gbm = xdpw_gbm_device_create(drmDev);
-	cast->pending_constraints.dirty = true;
-	logprint(TRACE, "ext: dmabuf_device handler");
+	if (cast->current_constraints.gbm && drmDevicesEqual(drmDev, cast->current_constraints.gbm->dmabuf_device)) {
+		logprint(TRACE, "ext dmabuf_device handler: drm device matches, reusing");
+		cast->pending_constraints.gbm = xdpw_gbm_device_ref(cast->current_constraints.gbm);
+		drmFreeDevice(&drmDev);
+	} else {
+		logprint(TRACE, "ext: dmabuf_device handler");
+		cast->pending_constraints.gbm = xdpw_gbm_device_create(drmDev);
+	}
 
-	drmFreeDevice(&drmDev);
+	cast->pending_constraints.dirty = true;
 }
 
 static void ext_session_dmabuf_format(void *data,

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -317,7 +317,7 @@ done:
 }
 
 void pwr_update_stream_param(struct xdpw_screencast_instance *cast) {
-	logprint(TRACE, "pipewire: stream update parameters");
+	logprint(TRACE, "pipewire: stream update parameters: %p", cast->stream);
 	struct pw_stream *stream = cast->stream;
 	if (stream == NULL) {
 		return;
@@ -381,7 +381,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	spa_format_video_raw_parse(param, &cast->pwr_format);
 	cast->framerate = (uint32_t)(cast->pwr_format.max_framerate.num / cast->pwr_format.max_framerate.denom);
 
-	struct gbm_device *gbm = cast->current_constraints.gbm ? cast->current_constraints.gbm : cast->ctx->gbm;
+	struct gbm_device *gbm = xdpw_get_gbm(cast);
 
 	const struct spa_pod_prop *prop_modifier;
 	if ((prop_modifier = spa_pod_find_prop(param, NULL, SPA_FORMAT_VIDEO_modifier)) != NULL) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -285,9 +285,7 @@ static void linux_dmabuf_feedback_tranche_target_devices(void *data,
 	}
 
 	if (ctx->gbm) {
-		drmDevice *drmDevRenderer = NULL;
-		drmGetDevice2(gbm_device_get_fd(ctx->gbm), /* flags */ 0, &drmDevRenderer);
-		ctx->feedback_data.device_used = drmDevicesEqual(drmDevRenderer, drmDev);
+		ctx->feedback_data.device_used = drmDevicesEqual(ctx->gbm->dmabuf_device, drmDev);
 	} else {
 		ctx->gbm = xdpw_gbm_device_create(drmDev);
 		ctx->feedback_data.device_used = ctx->gbm != NULL;
@@ -628,6 +626,8 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 		xdpw_screencast_instance_destroy(cast);
 	}
 
+	xdpw_gbm_device_unref(ctx->gbm);
+
 	if (ctx->screencopy_manager) {
 		zwlr_screencopy_manager_v1_destroy(ctx->screencopy_manager);
 	}
@@ -642,11 +642,6 @@ void xdpw_wlr_screencopy_finish(struct xdpw_screencast_context *ctx) {
 	}
 	if (ctx->shm) {
 		wl_shm_destroy(ctx->shm);
-	}
-	if (ctx->gbm) {
-		int fd = gbm_device_get_fd(ctx->gbm);
-		gbm_device_destroy(ctx->gbm);
-		close(fd);
 	}
 	if (ctx->linux_dmabuf_feedback) {
 		zwp_linux_dmabuf_feedback_v1_destroy(ctx->linux_dmabuf_feedback);


### PR DESCRIPTION
Whenever buffer constraints change, we will be re-informed of the main device even if it hasn't changed. This means that during resize of a toplevel capture, we will constantly be creating and destroying gbm devices for no good reason.

To avoid becoming a stress-test of driver init and teardown paths, wrap the gbm device in a refcounted container and ref it if the drm device hasn't changed.