### PR TITLE
pipewire: Allow 1 to 2 buffers instead of 2 to 32

### DIFF
--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -3,3 +3,4 @@ output_name=
 max_fps=30
 chooser_cmd=slurp -f %o -or
 chooser_type=simple
+max_buffers=2

--- a/include/config.h
+++ b/include/config.h
@@ -12,6 +12,7 @@ struct config_screencast {
 	char *chooser_cmd;
 	enum xdpw_chooser_types chooser_type;
 	bool force_mod_linear;
+	uint32_t max_buffers;
 };
 
 struct xdpw_config {

--- a/include/pipewire_screencast.h
+++ b/include/pipewire_screencast.h
@@ -3,8 +3,8 @@
 
 #include "screencast_common.h"
 
-#define XDPW_PWR_BUFFERS 2
-#define XDPW_PWR_BUFFERS_MIN 2
+#define XDPW_PWR_BUFFERS_MIN 1
+#define XDPW_PWR_BUFFERS_MAX 2
 #define XDPW_PWR_ALIGN 16
 
 void xdpw_pwr_enqueue_buffer(struct xdpw_screencast_instance *cast);

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -17,6 +17,7 @@ void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config) {
 	logprint(loglevel, "config: chooser_cmd: %s", config->screencast_conf.chooser_cmd);
 	logprint(loglevel, "config: chooser_type: %s", chooser_type_str(config->screencast_conf.chooser_type));
 	logprint(loglevel, "config: force_mod_linear: %d", config->screencast_conf.force_mod_linear);
+	logprint(loglevel, "config: max_buffers: %u", config->screencast_conf.max_buffers);
 }
 
 // NOTE: calling finish_config won't prepare the config to be read again from config file
@@ -38,6 +39,19 @@ static void parse_string(char **dest, const char* value) {
 	}
 	free(*dest);
 	*dest = strdup(value);
+}
+
+static void parse_uint32(uint32_t *dest, const char* value) {
+	if (value == NULL || *value == '\0') {
+		logprint(TRACE, "config: skipping empty value in config file");
+		return;
+	}
+	long v = strtol(value, (char**)NULL, 10);
+	if (v < 0) {
+		logprint(ERROR, "config: skipping negative value");
+		return;
+	}
+	*dest = v;
 }
 
 static void parse_double(double *dest, const char* value) {
@@ -78,6 +92,8 @@ static int handle_ini_screencast(struct config_screencast *screencast_conf, cons
 		free(chooser_type);
 	} else if (strcmp(key, "force_mod_linear") == 0) {
 		parse_bool(&screencast_conf->force_mod_linear, value);
+	} else if (strcmp(key, "max_buffers") == 0) {
+		parse_uint32(&screencast_conf->max_buffers, value);
 	} else {
 		logprint(TRACE, "config: skipping invalid key in config file");
 		return 0;
@@ -99,6 +115,7 @@ static int handle_ini_config(void *data, const char* section, const char *key, c
 
 static void default_config(struct xdpw_config *config) {
 	config->screencast_conf.max_fps = 0;
+	config->screencast_conf.max_buffers = 0;
 	config->screencast_conf.chooser_type = XDPW_CHOOSER_DEFAULT;
 }
 

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -27,7 +27,7 @@ static struct spa_pod *build_buffer(struct spa_pod_builder *b, uint32_t blocks, 
 
 	spa_pod_builder_push_object(b, &f[0], SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers);
 	spa_pod_builder_add(b, SPA_PARAM_BUFFERS_buffers,
-			SPA_POD_CHOICE_RANGE_Int(XDPW_PWR_BUFFERS, XDPW_PWR_BUFFERS_MIN, 32), 0);
+			SPA_POD_CHOICE_RANGE_Int(XDPW_PWR_BUFFERS_MIN, XDPW_PWR_BUFFERS_MIN, XDPW_PWR_BUFFERS_MAX), 0);
 	spa_pod_builder_add(b, SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(blocks), 0);
 	if (size > 0) {
 		spa_pod_builder_add(b, SPA_PARAM_BUFFERS_size, SPA_POD_Int(size), 0);

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -79,6 +79,14 @@ These options need to be placed under the **[screencast]** section.
 
 	This option is experimental and can be removed or replaced in future versions.
 
+**max_buffers** = _limit_
+	Set the maximum number of buffers that will be offered to pipewire.
+
+	This is useful to avoid excessive buffer allocation when sinks try to
+	negotiate an unnecessarily high number of buffers. A lower number can
+	significantly speed up buffer reallocation, which is especially useful
+	during resize of a captured toplevel.
+
 ## OUTPUT CHOOSER
 
 The chooser can be any program or script with the following behaviour:


### PR DESCRIPTION
Pipewire negotiates the amount of buffers that we will need to allocate with the client. If a client asks for between 1 and 32 with a default of 8, we end up allocating 8 because we allow it and our default is lower.

We don't really benefit from having more than 2 buffers in rotation, so set that as our upper limit. Clients like libwebrtc that default to 8 throw away all buffers but the latest one anyway. The more buffers are negotiated, the more buffers we have to allocate *up front* on every constraint mismatch, and we end up being blamed in memory accounting.

Use a range of 1 to 2 with a default of 1 instead of 2 to 32 buffers.