### PR TITLE
Only reallocate gbm device if it changed

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -164,8 +164,8 @@ struct xdpw_buffer_constraints {
 	struct wl_array dmabuf_format_modifier_pairs;
 	struct wl_array shm_formats;
 	uint32_t width, height;
+	dev_t dmabuf_device;
 	bool dirty;
-	struct gbm_device *gbm;
 };
 
 struct xdpw_screencast_ext_session {
@@ -239,6 +239,7 @@ struct xdpw_wlr_output {
 
 void randname(char *buf);
 struct gbm_device *xdpw_gbm_device_create(drmDevice *device);
+void xdpw_gbm_device_update(struct xdpw_screencast_instance *cast);
 struct xdpw_buffer *xdpw_buffer_create(struct xdpw_screencast_instance *cast,
 	enum buffer_type buffer_type);
 void xdpw_buffer_destroy(struct xdpw_buffer *buffer);

--- a/src/screencast/ext_image_copy.c
+++ b/src/screencast/ext_image_copy.c
@@ -77,18 +77,9 @@ static void ext_session_dmabuf_device(void *data,
 
 	dev_t device;
 	assert(device_arr->size == sizeof(device));
-	memcpy(&device, device_arr->data, sizeof(device));
-
-	drmDevice *drmDev;
-	if (drmGetDeviceFromDevId(device, /* flags */ 0, &drmDev) != 0) {
-		return;
-	}
-
-	cast->pending_constraints.gbm = xdpw_gbm_device_create(drmDev);
+	memcpy(&cast->pending_constraints.dmabuf_device, device_arr->data, sizeof(device));
 	cast->pending_constraints.dirty = true;
 	logprint(TRACE, "ext: dmabuf_device handler");
-
-	drmFreeDevice(&drmDev);
 }
 
 static void ext_session_dmabuf_format(void *data,
@@ -141,6 +132,7 @@ static void ext_session_done(void *data,
 
 	if (xdpw_buffer_constraints_move(&cast->current_constraints, &cast->pending_constraints)) {
 		logprint(DEBUG, "ext: buffer constraints changed");
+		xdpw_gbm_device_update(cast);
 		pwr_update_stream_param(cast);
 		return;
 	}

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -381,8 +381,6 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	spa_format_video_raw_parse(param, &cast->pwr_format);
 	cast->framerate = (uint32_t)(cast->pwr_format.max_framerate.num / cast->pwr_format.max_framerate.denom);
 
-	struct gbm_device *gbm = cast->current_constraints.gbm ? cast->current_constraints.gbm : cast->ctx->gbm;
-
 	const struct spa_pod_prop *prop_modifier;
 	if ((prop_modifier = spa_pod_find_prop(param, NULL, SPA_FORMAT_VIDEO_modifier)) != NULL) {
 		cast->buffer_type = DMABUF;
@@ -398,7 +396,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 			uint32_t flags = GBM_BO_USE_RENDERING;
 			uint64_t modifier;
 
-			struct gbm_bo *bo = gbm_bo_create_with_modifiers2(gbm,
+			struct gbm_bo *bo = gbm_bo_create_with_modifiers2(cast->ctx->gbm,
 				cast->current_constraints.width, cast->current_constraints.height,
 				fourcc, modifiers, n_modifiers, flags);
 			if (bo) {
@@ -420,7 +418,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 				default:
 					continue;
 				}
-				bo = gbm_bo_create(gbm, cast->current_constraints.width,
+				bo = gbm_bo_create(cast->ctx->gbm, cast->current_constraints.width,
 						cast->current_constraints.height, fourcc, flags);
 				if (bo) {
 					modifier = gbm_bo_get_modifier(bo);
@@ -455,7 +453,7 @@ fixate_format:
 		if (cast->pwr_format.modifier == DRM_FORMAT_MOD_INVALID) {
 			blocks = 1;
 		} else {
-			blocks = gbm_device_get_format_modifier_plane_count(gbm,
+			blocks = gbm_device_get_format_modifier_plane_count(cast->ctx->gbm,
 				fourcc, cast->pwr_format.modifier);
 		}
 	} else {


### PR DESCRIPTION
We are notified of the dmabuf_device every time buffer constraints change. Currently, this means that we destroy and reinitialize the gbm device (and possibly the driver backing it) every time constraints changed, which for toplevel capture is quite often during e.g., resize.

Instead, just store the dev_t, and when the constraints are applied, only reinitialize the gbm device if drmDevicesEqual reports that we are dealing with a different device.