### PR TITLE
announce wlr for use in volare

### DIFF
--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
 Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=wlroots;sway;Wayfire;river;phosh;Hyprland;
+UseIn=wlroots;sway;Wayfire;river;phosh;Hyprland;volare;


### PR DESCRIPTION
volare is a Sway fork https://codeberg.org/raboof/volare

I understand wlr.portal isn't the 'modern' way to find portal implementations anymore
(https://github.com/emersion/xdg-desktop-portal-wlr/pull/295) but this was an easy way to make screen sharing work. Can you point me in the right direction for the 'proper' solution? :)