### PR TITLE
screencast: include output description in menu chooser

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -227,6 +227,7 @@ struct xdpw_wlr_output {
 	struct wl_output *output;
 	struct zxdg_output_v1 *xdg_output;
 	char *name;
+	char *description;
 	int x;
 	int y;
 	int width;

--- a/src/screencast/chooser.c
+++ b/src/screencast/chooser.c
@@ -111,8 +111,12 @@ static char *read_chooser_out(FILE *f) {
 	return name;
 }
 
-static char *get_output_label(struct xdpw_wlr_output *output) {
-	return format_str("Monitor: %s", output->name);
+static char *get_output_label(struct xdpw_wlr_output *output, enum xdpw_chooser_types chooser_type) {
+	if (chooser_type == XDPW_CHOOSER_DMENU) {
+		return format_str("Monitor: %s %s", output->name, output->description);
+	} else {
+		return format_str("Monitor: %s", output->name);
+	}
 }
 
 static char *get_toplevel_label(struct xdpw_toplevel *toplevel, enum xdpw_chooser_types chooser_type) {
@@ -140,7 +144,7 @@ static bool wlr_chooser(const struct xdpw_chooser *chooser,
 		if (type_mask & MONITOR) {
 			struct xdpw_wlr_output *out;
 			wl_list_for_each(out, &ctx->output_list, link) {
-				char *label = get_output_label(out);
+				char *label = get_output_label(out, chooser->type);
 				fprintf(chooser_in, "%s\n", label);
 				free(label);
 			}
@@ -175,7 +179,7 @@ static bool wlr_chooser(const struct xdpw_chooser *chooser,
 	bool found = false;
 	struct xdpw_wlr_output *out;
 	wl_list_for_each(out, &ctx->output_list, link) {
-		char *label = get_output_label(out);
+		char *label = get_output_label(out, chooser->type);
 		found = strcmp(selected_label, label) == 0;
 		free(label);
 		if (found) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -100,7 +100,9 @@ static void wlr_output_handle_name(void *data, struct wl_output *wl_output,
 
 static void wlr_output_handle_description(void *data, struct wl_output *wl_output,
 		const char *description) {
-	/* Nothing to do */
+	struct xdpw_wlr_output *output = data;
+	free(output->description);
+	output->description = strdup(description);
 }
 
 static const struct wl_output_listener wlr_output_listener = {
@@ -184,6 +186,7 @@ bool xdpw_wlr_target_from_data(struct xdpw_screencast_context *ctx, struct xdpw_
 
 static void wlr_remove_output(struct xdpw_wlr_output *out) {
 	free(out->name);
+	free(out->description);
 	if (out->xdg_output) {
 		zxdg_output_v1_destroy(out->xdg_output);
 	}


### PR DESCRIPTION
Can be handy to make it easier to spot a particular output in the list.