### PR TITLE
screencast: drop xdpw_wlr_output.{make,model}

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -226,8 +226,6 @@ struct xdpw_wlr_output {
 	uint32_t id;
 	struct wl_output *output;
 	struct zxdg_output_v1 *xdg_output;
-	char *make;
-	char *model;
 	char *name;
 	int x;
 	int y;

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -139,8 +139,8 @@ bool setup_target(struct xdpw_screencast_context *ctx, struct xdpw_session *sess
 	if (type_mask & MONITOR) {
 		struct xdpw_wlr_output *output;
 		wl_list_for_each(output, &ctx->output_list, link) {
-			logprint(INFO, "wlroots: capturable output: %s model: %s id: %i name: %s",
-				output->make, output->model, output->id, output->name);
+			logprint(INFO, "wlroots: capturable output: %i %s",
+				output->id, output->name);
 		}
 	}
 	if (type_mask & WINDOW) {

--- a/src/screencast/wlr_screencast.c
+++ b/src/screencast/wlr_screencast.c
@@ -72,8 +72,6 @@ static void wlr_output_handle_geometry(void *data, struct wl_output *wl_output,
 		int32_t x, int32_t y, int32_t phys_width, int32_t phys_height,
 		int32_t subpixel, const char *make, const char *model, int32_t transform) {
 	struct xdpw_wlr_output *output = data;
-	output->make = strdup(make);
-	output->model = strdup(model);
 	output->transformation = transform;
 }
 
@@ -186,8 +184,6 @@ bool xdpw_wlr_target_from_data(struct xdpw_screencast_context *ctx, struct xdpw_
 
 static void wlr_remove_output(struct xdpw_wlr_output *out) {
 	free(out->name);
-	free(out->make);
-	free(out->model);
 	if (out->xdg_output) {
 		zxdg_output_v1_destroy(out->xdg_output);
 	}


### PR DESCRIPTION
These are just used for logging and not really useful. The output description is a better string to present to the user. wlroots leaves make/model as "Unknown" nowadays.