### PR TITLE
Implemented InputCapture protocol (issue #278)

### DIFF
--- a/contrib/wlroots-portals.conf
+++ b/contrib/wlroots-portals.conf
@@ -4,4 +4,5 @@ default=gtk
 # ... except for the ScreenCast, Screenshot and Settings (dark/light mode) interface
 org.freedesktop.impl.portal.ScreenCast=wlr
 org.freedesktop.impl.portal.Screenshot=wlr
+org.freedesktop.impl.portal.InputCapture=wlr
 org.freedesktop.impl.portal.Settings=darkman

--- a/include/input_capture.h
+++ b/include/input_capture.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "xdpw.h"
+
+#include <systemd/sd-bus.h>
+#include <libei-1.0/libeis.h>
+#include <wayland-client.h>
+#include <wayland-util.h>
+#include <xkbcommon/xkbcommon.h>
+
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "pointer-constraints-unstable-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+
+#include <stdbool.h>
+
+struct xdpw_input_capture_barrier {
+  uint32_t id;
+  int32_t x1, y1, x2, y2;
+  struct xdpw_input_capture_barrier *next;
+};
+
+struct xdpw_input_capture_output {
+  struct wl_list link;
+  struct xdpw_input_capture_data *data;
+  uint32_t name;
+  struct wl_output *wl_output;
+  int32_t x, y, width, height;
+  bool ready;
+};
+
+struct xdpw_input_capture_data {
+  struct xdpw_state *xdpw_state;
+
+  uint32_t capabilities;
+  uint32_t version;
+  sd_bus *bus;
+  struct eis *eis_context;
+
+  struct wl_display *wl_display;
+  struct wl_registry *wl_registry;
+  struct wl_compositor *wl_compositor;
+  struct zwlr_layer_shell_v1 *wl_layer_shell;
+
+  struct wl_seat* wl_seat;
+  struct zwp_pointer_constraints_v1 *wl_pointer_constraints;
+  struct zwp_keyboard_shortcuts_inhibit_manager_v1 *wl_keyboard_shortcuts_manager;
+  
+  struct xkb_context *xkb_context;  // global XKB context
+
+  struct xdpw_session *active_session;  // pointer to the currently capturing session
+
+  struct wl_list output_list;
+};
+
+int xdpw_input_capture_init(struct xdpw_state *);
+void xdpw_input_capture_destroy(void);
+void xdpw_input_capture_dispatch_eis(struct xdpw_state *);

--- a/include/input_capture_common.h
+++ b/include/input_capture_common.h
@@ -1,0 +1,36 @@
+#ifndef INPUT_CAPTURE_COMMON_H
+#define INPUT_CAPTURE_COMMON_H
+
+#include "input_capture.h"
+
+struct xdpw_input_capture_session_data {
+  
+  uint32_t capabilities;
+  bool enabled;
+  struct eis_device *device;
+  
+  uint32_t activation_id;
+  
+  uint32_t zone_set_id;
+  struct xdpw_input_capture_barrier *barriers; // Linked list of active barriers
+  
+  struct wl_surface *wl_surface;
+  struct zwlr_layer_surface_v1 *wl_layer_surface; 
+  struct wl_pointer *wl_pointer;
+  struct wl_keyboard *wl_keyboard;
+  struct zwp_locked_pointer_v1 *wl_locked_pointer;
+  struct zwp_keyboard_shortcuts_inhibitor_v1 *wl_keyboard_inhibitor;
+  
+  // pointer position for delta calculation
+  wl_fixed_t last_pointer_x;
+  wl_fixed_t last_pointer_y;
+  
+  // xkb state
+  struct xkb_keymap *xkb_keymap;
+  struct xkb_state *xkb_state;
+};
+
+
+void xdpw_input_capture_session_data_free(struct xdpw_input_capture_session_data *);
+
+#endif

--- a/include/xdpw.h
+++ b/include/xdpw.h
@@ -12,6 +12,7 @@
 
 #include "screencast_common.h"
 #include "screenshot_common.h"
+#include "input_capture_common.h"
 #include "config.h"
 
 struct xdpw_state {
@@ -28,6 +29,10 @@ struct xdpw_state {
 	int timer_poll_fd;
 	struct wl_list timers;
 	struct xdpw_timer *next_timer;
+
+	struct {
+		int libei_fd;
+	} input_capture;
 };
 
 struct xdpw_request {
@@ -40,6 +45,7 @@ struct xdpw_session {
 	char *session_handle;
 	bool closed;
 	struct xdpw_screencast_session_data screencast_data;
+	struct xdpw_input_capture_session_data input_capture_data;
 };
 
 typedef void (*xdpw_event_loop_timer_func_t)(void *data);
@@ -60,6 +66,10 @@ enum {
 
 int xdpw_screenshot_init(struct xdpw_state *state);
 int xdpw_screencast_init(struct xdpw_state *state);
+
+int xdpw_input_capture_init(struct xdpw_state *state);
+void xdpw_input_capture_dispatch_eis(struct xdpw_state *state);
+void xdpw_input_capture_destroy(void);
 
 struct xdpw_request *xdpw_request_create(sd_bus *bus, const char *object_path);
 void xdpw_request_destroy(struct xdpw_request *req);

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,8 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.24')
 iniparser = dependency('inih')
 gbm = dependency('gbm')
 drm = dependency('libdrm')
+eis = dependency('libeis-1.0', required: false)
+xkbcommon = dependency('xkbcommon', required: false)
 
 epoll = dependency('', required: false)
 if not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>')
@@ -65,6 +67,7 @@ xdpw_files = files(
 	'src/screencast/wlr_screencopy.c',
 	'src/screencast/pipewire_screencast.c',
 	'src/screencast/fps_limit.c',
+	'src/input_capture/input_capture.c',
 )
 
 executable(
@@ -79,6 +82,8 @@ executable(
 		gbm,
 		drm,
 		epoll,
+		eis,
+		xkbcommon,
 	],
 	include_directories: [inc],
 	install: true,

--- a/protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
+++ b/protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="keyboard_shortcuts_inhibit_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for inhibiting the compositor keyboard shortcuts">
+    This protocol specifies a way for a client to request the compositor
+    to ignore its own keyboard shortcuts for a given seat, so that all
+    key events from that seat get forwarded to a surface.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zwp_keyboard_shortcuts_inhibit_manager_v1" version="1">
+    <description summary="context object for keyboard grab_manager">
+      A global interface used for inhibiting the compositor keyboard shortcuts.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Destroy the keyboard shortcuts inhibitor manager.
+      </description>
+    </request>
+
+    <request name="inhibit_shortcuts">
+      <description summary="create a new keyboard shortcuts inhibitor object">
+	Create a new keyboard shortcuts inhibitor object associated with
+	the given surface for the given seat.
+
+	If shortcuts are already inhibited for the specified seat and surface,
+	a protocol error "already_inhibited" is raised by the compositor.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_keyboard_shortcuts_inhibitor_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the surface that inhibits the keyboard shortcuts behavior"/>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat for which keyboard shortcuts should be disabled"/>
+    </request>
+
+    <enum name="error">
+      <entry name="already_inhibited"
+	     value="0"
+	     summary="the shortcuts are already inhibited for this surface"/>
+    </enum>
+  </interface>
+
+  <interface name="zwp_keyboard_shortcuts_inhibitor_v1" version="1">
+    <description summary="context object for keyboard shortcuts inhibitor">
+      A keyboard shortcuts inhibitor instructs the compositor to ignore
+      its own keyboard shortcuts when the associated surface has keyboard
+      focus. As a result, when the surface has keyboard focus on the given
+      seat, it will receive all key events originating from the specified
+      seat, even those which would normally be caught by the compositor for
+      its own shortcuts.
+
+      The Wayland compositor is however under no obligation to disable
+      all of its shortcuts, and may keep some special key combo for its own
+      use, including but not limited to one allowing the user to forcibly
+      restore normal keyboard events routing in the case of an unwilling
+      client. The compositor may also use the same key combo to reactivate
+      an existing shortcut inhibitor that was previously deactivated on
+      user request.
+
+      When the compositor restores its own keyboard shortcuts, an
+      "inactive" event is emitted to notify the client that the keyboard
+      shortcuts inhibitor is not effectively active for the surface and
+      seat any more, and the client should not expect to receive all
+      keyboard events.
+
+      When the keyboard shortcuts inhibitor is inactive, the client has
+      no way to forcibly reactivate the keyboard shortcuts inhibitor.
+
+      The user can chose to re-enable a previously deactivated keyboard
+      shortcuts inhibitor using any mechanism the compositor may offer,
+      in which case the compositor will send an "active" event to notify
+      the client.
+
+      If the surface is destroyed, unmapped, or loses the seat's keyboard
+      focus, the keyboard shortcuts inhibitor becomes irrelevant and the
+      compositor will restore its own keyboard shortcuts but no "inactive"
+      event is emitted in this case.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Remove the keyboard shortcuts inhibitor from the associated wl_surface.
+      </description>
+    </request>
+
+    <event name="active">
+      <description summary="shortcuts are inhibited">
+	This event indicates that the shortcut inhibitor is active.
+
+	The compositor sends this event every time compositor shortcuts
+	are inhibited on behalf of the surface. When active, the client
+	may receive input events normally reserved by the compositor
+	(see zwp_keyboard_shortcuts_inhibitor_v1).
+
+	This occurs typically when the initial request "inhibit_shortcuts"
+	first becomes active or when the user instructs the compositor to
+	re-enable and existing shortcuts inhibitor using any mechanism
+	offered by the compositor.
+      </description>
+    </event>
+
+    <event name="inactive">
+      <description summary="shortcuts are restored">
+	This event indicates that the shortcuts inhibitor is inactive,
+	normal shortcuts processing is restored by the compositor.
+       </description>
+    </event>
+  </interface>
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -13,6 +13,10 @@ client_protocols = [
 	wl_protocol_dir / 'staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml',
 	wl_protocol_dir / 'staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml',
 	'wlr-screencopy-unstable-v1.xml',
+	'keyboard-shortcuts-inhibit-unstable-v1.xml',
+	'pointer-constraints-unstable-v1.xml',
+	'wlr-layer-shell-unstable-v1.xml',
+	'xdg-shell.xml',
 ]
 
 wl_proto_files = []

--- a/protocols/pointer-constraints-unstable-v1.xml
+++ b/protocols/pointer-constraints-unstable-v1.xml
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="pointer_constraints_unstable_v1">
+
+  <copyright>
+    Copyright © 2014      Jonas Ådahl
+    Copyright © 2015      Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="protocol for constraining pointer motions">
+    This protocol specifies a set of interfaces used for adding constraints to
+    the motion of a pointer. Possible constraints include confining pointer
+    motions to a given region, or locking it to its current position.
+
+    In order to constrain the pointer, a client must first bind the global
+    interface "wp_pointer_constraints" which, if a compositor supports pointer
+    constraints, is exposed by the registry. Using the bound global object, the
+    client uses the request that corresponds to the type of constraint it wants
+    to make. See wp_pointer_constraints for more details.
+
+    Warning! The protocol described in this file is experimental and backward
+    incompatible changes may be made. Backward compatible changes may be added
+    together with the corresponding interface version bump. Backward
+    incompatible changes are done by bumping the version number in the protocol
+    and interface names and resetting the interface version. Once the protocol
+    is to be declared stable, the 'z' prefix and the version number in the
+    protocol and interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zwp_pointer_constraints_v1" version="1">
+    <description summary="constrain the movement of a pointer">
+      The global interface exposing pointer constraining functionality. It
+      exposes two requests: lock_pointer for locking the pointer to its
+      position, and confine_pointer for locking the pointer to a region.
+
+      The lock_pointer and confine_pointer requests create the objects
+      wp_locked_pointer and wp_confined_pointer respectively, and the client can
+      use these objects to interact with the lock.
+
+      For any surface, only one lock or confinement may be active across all
+      wl_pointer objects of the same seat. If a lock or confinement is requested
+      when another lock or confinement is active or requested on the same surface
+      and with any of the wl_pointer objects of the same seat, an
+      'already_constrained' error will be raised.
+    </description>
+
+    <enum name="error">
+      <description summary="wp_pointer_constraints error values">
+	These errors can be emitted in response to wp_pointer_constraints
+	requests.
+      </description>
+      <entry name="already_constrained" value="1"
+	     summary="pointer constraint already requested on that surface"/>
+    </enum>
+
+    <enum name="lifetime">
+      <description summary="constraint lifetime">
+	These values represent different lifetime semantics. They are passed
+	as arguments to the factory requests to specify how the constraint
+	lifetimes should be managed.
+      </description>
+      <entry name="oneshot" value="1">
+	<description summary="the pointer constraint is defunct once deactivated">
+	  A oneshot pointer constraint will never reactivate once it has been
+	  deactivated. See the corresponding deactivation event
+	  (wp_locked_pointer.unlocked and wp_confined_pointer.unconfined) for
+	  details.
+	</description>
+      </entry>
+      <entry name="persistent" value="2">
+	<description summary="the pointer constraint may reactivate">
+	  A persistent pointer constraint may again reactivate once it has
+	  been deactivated. See the corresponding deactivation event
+	  (wp_locked_pointer.unlocked and wp_confined_pointer.unconfined) for
+	  details.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the pointer constraints manager object">
+	Used by the client to notify the server that it will no longer use this
+	pointer constraints object.
+      </description>
+    </request>
+
+    <request name="lock_pointer">
+      <description summary="lock pointer to a position">
+	The lock_pointer request lets the client request to disable movements of
+	the virtual pointer (i.e. the cursor), effectively locking the pointer
+	to a position. This request may not take effect immediately; in the
+	future, when the compositor deems implementation-specific constraints
+	are satisfied, the pointer lock will be activated and the compositor
+	sends a locked event.
+
+	The protocol provides no guarantee that the constraints are ever
+	satisfied, and does not require the compositor to send an error if the
+	constraints cannot ever be satisfied. It is thus possible to request a
+	lock that will never activate.
+
+	There may not be another pointer constraint of any kind requested or
+	active on the surface for any of the wl_pointer objects of the seat of
+	the passed pointer when requesting a lock. If there is, an error will be
+	raised. See general pointer lock documentation for more details.
+
+	The intersection of the region passed with this request and the input
+	region of the surface is used to determine where the pointer must be
+	in order for the lock to activate. It is up to the compositor whether to
+	warp the pointer or require some kind of user interaction for the lock
+	to activate. If the region is null the surface input region is used.
+
+	A surface may receive pointer focus without the lock being activated.
+
+	The request creates a new object wp_locked_pointer which is used to
+	interact with the lock as well as receive updates about its state. See
+	the the description of wp_locked_pointer for further information.
+
+	Note that while a pointer is locked, the wl_pointer objects of the
+	corresponding seat will not emit any wl_pointer.motion events, but
+	relative motion events will still be emitted via wp_relative_pointer
+	objects of the same seat. wl_pointer.axis and wl_pointer.button events
+	are unaffected.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_locked_pointer_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="surface to lock pointer to"/>
+      <arg name="pointer" type="object" interface="wl_pointer"
+	   summary="the pointer that should be locked"/>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="region of surface"/>
+      <arg name="lifetime" type="uint" enum="lifetime" summary="lock lifetime"/>
+    </request>
+
+    <request name="confine_pointer">
+      <description summary="confine pointer to a region">
+	The confine_pointer request lets the client request to confine the
+	pointer cursor to a given region. This request may not take effect
+	immediately; in the future, when the compositor deems implementation-
+	specific constraints are satisfied, the pointer confinement will be
+	activated and the compositor sends a confined event.
+
+	The intersection of the region passed with this request and the input
+	region of the surface is used to determine where the pointer must be
+	in order for the confinement to activate. It is up to the compositor
+	whether to warp the pointer or require some kind of user interaction for
+	the confinement to activate. If the region is null the surface input
+	region is used.
+
+	The request will create a new object wp_confined_pointer which is used
+	to interact with the confinement as well as receive updates about its
+	state. See the the description of wp_confined_pointer for further
+	information.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_confined_pointer_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="surface to lock pointer to"/>
+      <arg name="pointer" type="object" interface="wl_pointer"
+	   summary="the pointer that should be confined"/>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="region of surface"/>
+      <arg name="lifetime" type="uint" enum="lifetime" summary="confinement lifetime"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_locked_pointer_v1" version="1">
+    <description summary="receive relative pointer motion events">
+      The wp_locked_pointer interface represents a locked pointer state.
+
+      While the lock of this object is active, the wl_pointer objects of the
+      associated seat will not emit any wl_pointer.motion events.
+
+      This object will send the event 'locked' when the lock is activated.
+      Whenever the lock is activated, it is guaranteed that the locked surface
+      will already have received pointer focus and that the pointer will be
+      within the region passed to the request creating this object.
+
+      To unlock the pointer, send the destroy request. This will also destroy
+      the wp_locked_pointer object.
+
+      If the compositor decides to unlock the pointer the unlocked event is
+      sent. See wp_locked_pointer.unlock for details.
+
+      When unlocking, the compositor may warp the cursor position to the set
+      cursor position hint. If it does, it will not result in any relative
+      motion events emitted via wp_relative_pointer.
+
+      If the surface the lock was requested on is destroyed and the lock is not
+      yet activated, the wp_locked_pointer object is now defunct and must be
+      destroyed.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the locked pointer object">
+	Destroy the locked pointer object. If applicable, the compositor will
+	unlock the pointer.
+      </description>
+    </request>
+
+    <request name="set_cursor_position_hint">
+      <description summary="set the pointer cursor position hint">
+	Set the cursor position hint relative to the top left corner of the
+	surface.
+
+	If the client is drawing its own cursor, it should update the position
+	hint to the position of its own cursor. A compositor may use this
+	information to warp the pointer upon unlock in order to avoid pointer
+	jumps.
+
+	The cursor position hint is double-buffered state, see
+	wl_surface.commit.
+      </description>
+      <arg name="surface_x" type="fixed"
+	   summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed"
+	   summary="surface-local y coordinate"/>
+    </request>
+
+    <request name="set_region">
+      <description summary="set a new lock region">
+	Set a new region used to lock the pointer.
+
+	The new lock region is double-buffered, see wl_surface.commit.
+
+	For details about the lock region, see wp_locked_pointer.
+      </description>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="region of surface"/>
+    </request>
+
+    <event name="locked">
+      <description summary="lock activation event">
+	Notification that the pointer lock of the seat's pointer is activated.
+      </description>
+    </event>
+
+    <event name="unlocked">
+      <description summary="lock deactivation event">
+	Notification that the pointer lock of the seat's pointer is no longer
+	active. If this is a oneshot pointer lock (see
+	wp_pointer_constraints.lifetime) this object is now defunct and should
+	be destroyed. If this is a persistent pointer lock (see
+	wp_pointer_constraints.lifetime) this pointer lock may again
+	reactivate in the future.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwp_confined_pointer_v1" version="1">
+    <description summary="confined pointer object">
+      The wp_confined_pointer interface represents a confined pointer state.
+
+      This object will send the event 'confined' when the confinement is
+      activated. Whenever the confinement is activated, it is guaranteed that
+      the surface the pointer is confined to will already have received pointer
+      focus and that the pointer will be within the region passed to the request
+      creating this object. It is up to the compositor to decide whether this
+      requires some user interaction and if the pointer will warp to within the
+      passed region if outside.
+
+      To unconfine the pointer, send the destroy request. This will also destroy
+      the wp_confined_pointer object.
+
+      If the compositor decides to unconfine the pointer the unconfined event is
+      sent. The wp_confined_pointer object is at this point defunct and should
+      be destroyed.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the confined pointer object">
+	Destroy the confined pointer object. If applicable, the compositor will
+	unconfine the pointer.
+      </description>
+    </request>
+
+    <request name="set_region">
+      <description summary="set a new confine region">
+	Set a new region used to confine the pointer.
+
+	The new confine region is double-buffered, see wl_surface.commit.
+
+	If the confinement is active when the new confinement region is applied
+	and the pointer ends up outside of newly applied region, the pointer may
+	warped to a position within the new confinement region. If warped, a
+	wl_pointer.motion event will be emitted, but no
+	wp_relative_pointer.relative_motion event.
+
+	The compositor may also, instead of using the new region, unconfine the
+	pointer.
+
+	For details about the confine region, see wp_confined_pointer.
+      </description>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="region of surface"/>
+    </request>
+
+    <event name="confined">
+      <description summary="pointer confined">
+	Notification that the pointer confinement of the seat's pointer is
+	activated.
+      </description>
+    </event>
+
+    <event name="unconfined">
+      <description summary="pointer unconfined">
+	Notification that the pointer confinement of the seat's pointer is no
+	longer active. If this is a oneshot pointer confinement (see
+	wp_pointer_constraints.lifetime) this object is now defunct and should
+	be destroyed. If this is a persistent pointer confinement (see
+	wp_pointer_constraints.lifetime) this pointer confinement may again
+	reactivate in the future.
+      </description>
+    </event>
+  </interface>
+
+</protocol>

--- a/protocols/wlr-layer-shell-unstable-v1.xml
+++ b/protocols/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="5">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="5">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
+      <entry name="invalid_exclusive_edge" value="4" summary="exclusive edge is invalid given the surface anchors"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
+
+    <!-- Version 5 additions -->
+
+    <request name="set_exclusive_edge" since="5">
+      <description summary="set the edge the exclusive zone will be applied to">
+        Requests an edge for the exclusive zone to apply. The exclusive
+        edge will be automatically deduced from anchor points when possible,
+        but when the surface is anchored to a corner, it will be necessary
+        to set it explicitly to disambiguate, as it is not possible to deduce
+        which one of the two corner edges should be used.
+
+        The edge must be one the surface is anchored to, otherwise the
+        invalid_exclusive_edge protocol error will be raised.
+      </description>
+      <arg name="edge" type="uint" enum="anchor"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocols/xdg-shell.xml
+++ b/protocols/xdg-shell.xml
@@ -1,0 +1,1418 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_shell">
+
+  <copyright>
+    Copyright © 2008-2013 Kristian Høgsberg
+    Copyright © 2013      Rafael Antognolli
+    Copyright © 2013      Jasper St. Pierre
+    Copyright © 2010-2013 Intel Corporation
+    Copyright © 2015-2017 Samsung Electronics Co., Ltd
+    Copyright © 2015-2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_wm_base" version="7">
+    <description summary="create desktop-style surfaces">
+      The xdg_wm_base interface is exposed as a global object enabling clients
+      to turn their wl_surfaces into windows in a desktop environment. It
+      defines the basic functionality needed for clients and the compositor to
+      create windows that can be dragged, resized, maximized, etc, as well as
+      creating transient windows such as popup menus.
+    </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+      <entry name="defunct_surfaces" value="1"
+	     summary="xdg_wm_base was destroyed before children"/>
+      <entry name="not_the_topmost_popup" value="2"
+	     summary="the client tried to map or destroy a non-topmost popup"/>
+      <entry name="invalid_popup_parent" value="3"
+	     summary="the client specified an invalid popup parent surface"/>
+      <entry name="invalid_surface_state" value="4"
+	     summary="the client provided an invalid surface state"/>
+      <entry name="invalid_positioner" value="5"
+	     summary="the client provided an invalid positioner"/>
+      <entry name="unresponsive" value="6"
+	     summary="the client didn’t respond to a ping event in time"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy xdg_wm_base">
+	Destroy this xdg_wm_base object.
+
+	Destroying a bound xdg_wm_base object while there are surfaces
+	still alive created by this xdg_wm_base object instance is illegal
+	and will result in a defunct_surfaces error.
+      </description>
+    </request>
+
+    <request name="create_positioner">
+      <description summary="create a positioner object">
+	Create a positioner object. A positioner object is used to position
+	surfaces relative to some parent surface. See the interface description
+	and xdg_surface.get_popup for details.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_positioner"/>
+    </request>
+
+    <request name="get_xdg_surface">
+      <description summary="create a shell surface from a surface">
+	This creates an xdg_surface for the given surface. While xdg_surface
+	itself is not a role, the corresponding surface may only be assigned
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup. It is
+	illegal to create an xdg_surface for a wl_surface which already has an
+	assigned role and this will result in a role error.
+
+	This creates an xdg_surface for the given surface. An xdg_surface is
+	used as basis to define a role to a given surface, such as xdg_toplevel
+	or xdg_popup. It also manages functionality shared between xdg_surface
+	based surface roles.
+
+	See the documentation of xdg_surface for more details about what an
+	xdg_surface is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_surface"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="pong">
+      <description summary="respond to a ping event">
+	A client must respond to a ping event with a pong request or
+	the client may be deemed unresponsive. See xdg_wm_base.ping
+	and xdg_wm_base.error.unresponsive.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the ping event"/>
+    </request>
+
+    <event name="ping">
+      <description summary="check if the client is alive">
+	The ping event asks the client if it's still alive. Pass the
+	serial specified in the event back to the compositor by sending
+	a "pong" request back with the specified serial. See xdg_wm_base.pong.
+
+	Compositors can use this to determine if the client is still
+	alive. It's unspecified what will happen if the client doesn't
+	respond to the ping request, or in what timeframe. Clients should
+	try to respond in a reasonable amount of time. The “unresponsive”
+	error is provided for compositors that wish to disconnect unresponsive
+	clients.
+
+	A compositor is free to ping in any way it wants, but a client must
+	always respond to any xdg_wm_base object it created.
+      </description>
+      <arg name="serial" type="uint" summary="pass this to the pong request"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_positioner" version="7">
+    <description summary="child surface positioner">
+      The xdg_positioner provides a collection of rules for the placement of a
+      child surface relative to a parent surface. Rules can be defined to ensure
+      the child surface remains within the visible area's borders, and to
+      specify how the child surface changes its position, such as sliding along
+      an axis, or flipping around a rectangle. These positioner-created rules are
+      constrained by the requirement that a child surface must intersect with or
+      be at least partially adjacent to its parent surface.
+
+      See the various requests for details about possible rules.
+
+      At the time of the request, the compositor makes a copy of the rules
+      specified by the xdg_positioner. Thus, after the request is complete the
+      xdg_positioner object can be destroyed or reused; further changes to the
+      object will have no effect on previous usages.
+
+      For an xdg_positioner object to be considered complete, it must have a
+      non-zero size set by set_size, and a non-zero anchor rectangle set by
+      set_anchor_rect. Passing an incomplete xdg_positioner object when
+      positioning a surface raises an invalid_positioner error.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_input" value="0" summary="invalid input provided"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_positioner object">
+	Notify the compositor that the xdg_positioner will no longer be used.
+      </description>
+    </request>
+
+    <request name="set_size">
+      <description summary="set the size of the to-be positioned rectangle">
+	Set the size of the surface that is to be positioned with the positioner
+	object. The size is in surface-local coordinates and corresponds to the
+	window geometry. See xdg_surface.set_window_geometry.
+
+	If a zero or negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="width" type="int" summary="width of positioned rectangle"/>
+      <arg name="height" type="int" summary="height of positioned rectangle"/>
+    </request>
+
+    <request name="set_anchor_rect">
+      <description summary="set the anchor rectangle within the parent surface">
+	Specify the anchor rectangle within the parent surface that the child
+	surface will be placed relative to. The rectangle is relative to the
+	window geometry as defined by xdg_surface.set_window_geometry of the
+	parent surface.
+
+	When the xdg_positioner object is used to position a child surface, the
+	anchor rectangle may not extend outside the window geometry of the
+	positioned child's parent surface.
+
+	If a negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="x" type="int" summary="x position of anchor rectangle"/>
+      <arg name="y" type="int" summary="y position of anchor rectangle"/>
+      <arg name="width" type="int" summary="width of anchor rectangle"/>
+      <arg name="height" type="int" summary="height of anchor rectangle"/>
+    </request>
+
+    <enum name="anchor">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_anchor">
+      <description summary="set anchor rectangle anchor">
+	Defines the anchor point for the anchor rectangle. The specified anchor
+	is used derive an anchor point that the child surface will be
+	positioned relative to. If a corner anchor is set (e.g. 'top_left' or
+	'bottom_right'), the anchor point will be at the specified corner;
+	otherwise, the derived anchor point will be centered on the specified
+	edge, or in the center of the anchor rectangle if no edge is specified.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"
+	   summary="anchor"/>
+    </request>
+
+    <enum name="gravity">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_gravity">
+      <description summary="set child surface gravity">
+	Defines in what direction a surface should be positioned, relative to
+	the anchor point of the parent surface. If a corner gravity is
+	specified (e.g. 'bottom_right' or 'top_left'), then the child surface
+	will be placed towards the specified gravity; otherwise, the child
+	surface will be centered over the anchor point on any axis that had no
+	gravity specified. If the gravity is not in the ‘gravity’ enum, an
+	invalid_input error is raised.
+      </description>
+      <arg name="gravity" type="uint" enum="gravity"
+	   summary="gravity direction"/>
+    </request>
+
+    <enum name="constraint_adjustment" bitfield="true">
+      <description summary="constraint adjustments">
+	The constraint adjustment value define ways the compositor will adjust
+	the position of the surface, if the unadjusted position would result
+	in the surface being partly constrained.
+
+	Whether a surface is considered 'constrained' is left to the compositor
+	to determine. For example, the surface may be partly outside the
+	compositor's defined 'work area', thus necessitating the child surface's
+	position be adjusted until it is entirely inside the work area.
+
+	The adjustments can be combined, according to a defined precedence: 1)
+	Flip, 2) Slide, 3) Resize.
+      </description>
+      <entry name="none" value="0">
+	<description summary="don't move the child surface when constrained">
+	  Don't alter the surface position even if it is constrained on some
+	  axis, for example partially outside the edge of an output.
+	</description>
+      </entry>
+      <entry name="slide_x" value="1">
+	<description summary="move along the x axis until unconstrained">
+	  Slide the surface along the x axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the x axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  x axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="slide_y" value="2">
+	<description summary="move along the y axis until unconstrained">
+	  Slide the surface along the y axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the y axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  y axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="flip_x" value="4">
+	<description summary="invert the anchor and gravity on the x axis">
+	  Invert the anchor and gravity on the x axis if the surface is
+	  constrained on the x axis. For example, if the left edge of the
+	  surface is constrained, the gravity is 'left' and the anchor is
+	  'left', change the gravity to 'right' and the anchor to 'right'.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_x adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="flip_y" value="8">
+	<description summary="invert the anchor and gravity on the y axis">
+	  Invert the anchor and gravity on the y axis if the surface is
+	  constrained on the y axis. For example, if the bottom edge of the
+	  surface is constrained, the gravity is 'bottom' and the anchor is
+	  'bottom', change the gravity to 'top' and the anchor to 'top'.
+
+	  The adjusted position is calculated given the original anchor
+	  rectangle and offset, but with the new flipped anchor and gravity
+	  values.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_y adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="resize_x" value="16">
+	<description summary="horizontally resize the surface">
+	  Resize the surface horizontally so that it is completely
+	  unconstrained.
+	</description>
+      </entry>
+      <entry name="resize_y" value="32">
+	<description summary="vertically resize the surface">
+	  Resize the surface vertically so that it is completely unconstrained.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_constraint_adjustment">
+      <description summary="set the adjustment to be done when constrained">
+	Specify how the window should be positioned if the originally intended
+	position caused the surface to be constrained, meaning at least
+	partially outside positioning boundaries set by the compositor. The
+	adjustment is set by constructing a bitmask describing the adjustment to
+	be made when the surface is constrained on that axis.
+
+	If no bit for one axis is set, the compositor will assume that the child
+	surface should not change its position on that axis when constrained.
+
+	If more than one bit for one axis is set, the order of how adjustments
+	are applied is specified in the corresponding adjustment descriptions.
+
+	The default adjustment is none.
+      </description>
+      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
+	   summary="bit mask of constraint adjustments"/>
+    </request>
+
+    <request name="set_offset">
+      <description summary="set surface position offset">
+	Specify the surface position offset relative to the position of the
+	anchor on the anchor rectangle and the anchor on the surface. For
+	example if the anchor of the anchor rectangle is at (x, y), the surface
+	has the gravity bottom|right, and the offset is (ox, oy), the calculated
+	surface position will be (x + ox, y + oy). The offset position of the
+	surface is the one used for constraint testing. See
+	set_constraint_adjustment.
+
+	An example use case is placing a popup menu on top of a user interface
+	element, while aligning the user interface element of the parent surface
+	with some user interface element placed somewhere in the popup surface.
+      </description>
+      <arg name="x" type="int" summary="surface position x offset"/>
+      <arg name="y" type="int" summary="surface position y offset"/>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <request name="set_reactive" since="3">
+      <description summary="continuously reconstrain the surface">
+	When set reactive, the surface is reconstrained if the conditions used
+	for constraining changed, e.g. the parent window moved.
+
+	If the conditions changed and the popup was reconstrained, an
+	xdg_popup.configure event is sent with updated geometry, followed by an
+	xdg_surface.configure event.
+      </description>
+    </request>
+
+    <request name="set_parent_size" since="3">
+      <description summary="">
+	Set the parent window geometry the compositor should use when
+	positioning the popup. The compositor may use this information to
+	determine the future state the popup should be constrained using. If
+	this doesn't match the dimension of the parent the popup is eventually
+	positioned against, the behavior is undefined.
+
+	The arguments are given in the surface-local coordinate space.
+      </description>
+      <arg name="parent_width" type="int"
+	   summary="future window geometry width of parent"/>
+      <arg name="parent_height" type="int"
+	   summary="future window geometry height of parent"/>
+    </request>
+
+    <request name="set_parent_configure" since="3">
+      <description summary="set parent configure this is a response to">
+	Set the serial of an xdg_surface.configure event this positioner will be
+	used in response to. The compositor may use this information together
+	with set_parent_size to determine what future state the popup should be
+	constrained using.
+      </description>
+      <arg name="serial" type="uint"
+	   summary="serial of parent configure event"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_surface" version="7">
+    <description summary="desktop user interface surface base interface">
+      An interface that may be implemented by a wl_surface, for
+      implementations that provide a desktop-style user interface.
+
+      It provides a base set of functionality required to construct user
+      interface elements requiring management by the compositor, such as
+      toplevel windows, menus, etc. The types of functionality are split into
+      xdg_surface roles.
+
+      Creating an xdg_surface does not set the role for a wl_surface. In order
+      to map an xdg_surface, the client must create a role-specific object
+      using, e.g., get_toplevel, get_popup. The wl_surface for any given
+      xdg_surface can have at most one role, and may not be assigned any role
+      not based on xdg_surface.
+
+      A role must be assigned before any other requests are made to the
+      xdg_surface object.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_surface state to take effect.
+
+      Creating an xdg_surface from a wl_surface which has a buffer attached or
+      committed is a client error, and any attempts by a client to attach or
+      manipulate a buffer prior to the first xdg_surface.configure call must
+      also be treated as errors.
+
+      After creating a role-specific object and setting it up (e.g. by sending
+      the title, app ID, size constraints, parent, etc), the client must
+      perform an initial commit without any buffer attached. The compositor
+      will reply with initial wl_surface state such as
+      wl_surface.preferred_buffer_scale followed by an xdg_surface.configure
+      event. The client must acknowledge it and is then allowed to attach a
+      buffer to map the surface.
+
+      Mapping an xdg_surface-based role surface is defined as making it
+      possible for the surface to be shown by the compositor. Note that
+      a mapped surface is not guaranteed to be visible once it is mapped.
+
+      For an xdg_surface to be mapped by the compositor, the following
+      conditions must be met:
+      (1) the client has assigned an xdg_surface-based role to the surface
+      (2) the client has set and committed the xdg_surface state and the
+	  role-dependent state to the surface
+      (3) the client has committed a buffer to the surface
+
+      A newly-unmapped surface is considered to have met condition (1) out
+      of the 3 required conditions for mapping a surface if its role surface
+      has not been destroyed, i.e. the client must perform the initial commit
+      again before attaching a buffer.
+    </description>
+
+    <enum name="error">
+      <entry name="not_constructed" value="1"
+	     summary="Surface was not fully constructed"/>
+      <entry name="already_constructed" value="2"
+	     summary="Surface was already constructed"/>
+      <entry name="unconfigured_buffer" value="3"
+	     summary="Attaching a buffer to an unconfigured surface"/>
+      <entry name="invalid_serial" value="4"
+	     summary="Invalid serial number when acking a configure event"/>
+      <entry name="invalid_size" value="5"
+	     summary="Width or height was zero or negative"/>
+      <entry name="defunct_role_object" value="6"
+	     summary="Surface was destroyed before its role object"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_surface">
+	Destroy the xdg_surface object. An xdg_surface must only be destroyed
+	after its role object has been destroyed, otherwise
+	a defunct_role_object error is raised.
+      </description>
+    </request>
+
+    <request name="get_toplevel">
+      <description summary="assign the xdg_toplevel surface role">
+	This creates an xdg_toplevel object for the given xdg_surface and gives
+	the associated wl_surface the xdg_toplevel role.
+
+	See the documentation of xdg_toplevel for more details about what an
+	xdg_toplevel is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_toplevel"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign the xdg_popup surface role">
+	This creates an xdg_popup object for the given xdg_surface and gives
+	the associated wl_surface the xdg_popup role.
+
+	If null is passed as a parent, a parent surface must be specified using
+	some other protocol, before committing the initial state.
+
+	See the documentation of xdg_popup for more details about what an
+	xdg_popup is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_popup"/>
+      <arg name="parent" type="object" interface="xdg_surface" allow-null="true"/>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
+    </request>
+
+    <request name="set_window_geometry">
+      <description summary="set the new window geometry">
+	The window geometry of a surface is its "visible bounds" from the
+	user's perspective. Client-side decorations often have invisible
+	portions like drop-shadows which should be ignored for the
+	purposes of aligning, placing and constraining windows. Note that
+	in some situations, compositors may clip rendering to the window
+	geometry, so the client should avoid putting functional elements
+	outside of it.
+
+	The window geometry is double-buffered state, see wl_surface.commit.
+
+	When maintaining a position, the compositor should treat the (x, y)
+	coordinate of the window geometry as the top left corner of the window.
+	A client changing the (x, y) window geometry coordinate should in
+	general not alter the position of the window.
+
+	Once the window geometry of the surface is set, it is not possible to
+	unset it, and it will remain the same until set_window_geometry is
+	called again, even if a new subsurface or buffer is attached.
+
+	If never set, the value is the full bounds of the surface,
+	including any subsurfaces. This updates dynamically on every
+	commit. This unset is meant for extremely simple clients.
+
+	The arguments are given in the surface-local coordinate space of
+	the wl_surface associated with this xdg_surface, and may extend outside
+	of the wl_surface itself to mark parts of the subsurface tree as part of
+	the window geometry.
+
+	When applied, the effective window geometry will be the set window
+	geometry clamped to the bounding rectangle of the combined
+	geometry of the surface of the xdg_surface and the associated
+	subsurfaces.
+
+	The effective geometry will not be recalculated unless a new call to
+	set_window_geometry is done and the new pending surface state is
+	subsequently applied.
+
+	The width and height of the effective window geometry must be
+	greater than zero. Setting an invalid size will raise an
+	invalid_size error.
+      </description>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+	When a configure event is received, if a client commits the
+	surface in response to the configure event, then the client
+	must make an ack_configure request sometime before the commit
+	request, passing along the serial of the configure event.
+
+	For instance, for toplevel surfaces the compositor might use this
+	information to move a surface to the top left only when the client has
+	drawn itself for the maximized or fullscreen state.
+
+	If the client receives multiple configure events before it
+	can respond to one, it only has to ack the last configure event.
+	Acking a configure event that was never sent raises an invalid_serial
+	error.
+
+	A client is not required to commit immediately after sending
+	an ack_configure request - it may even ack_configure several times
+	before its next surface commit.
+
+	A client may send multiple ack_configure requests before committing, but
+	only the last request sent before a commit indicates which configure
+	event the client really is responding to.
+
+	Sending an ack_configure request consumes the serial number sent with
+	the request, as well as serial numbers sent by all configure events
+	sent on this xdg_surface prior to the configure event referenced by
+	the committed serial.
+
+	It is an error to issue multiple ack_configure requests referencing a
+	serial from the same configure event, or to issue an ack_configure
+	request referencing a serial from a configure event issued before the
+	event identified by the last ack_configure request for the same
+	xdg_surface. Doing so will raise an invalid_serial error.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	The configure event marks the end of a configure sequence. A configure
+	sequence is a set of one or more events configuring the state of the
+	xdg_surface, including the final xdg_surface.configure event.
+
+	Where applicable, xdg_surface surface roles will during a configure
+	sequence extend this event as a latched state sent as events before the
+	xdg_surface.configure event. Such events should be considered to make up
+	a set of atomically applied configuration states, where the
+	xdg_surface.configure commits the accumulated state.
+
+	Clients should arrange their surface for the new states, and then send
+	an ack_configure request with the serial sent in this configure event at
+	some point before committing the new surface.
+
+	If the client receives multiple configure events before it can respond
+	to one, it is free to discard all but the last event it received.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the configure event"/>
+    </event>
+
+  </interface>
+
+  <interface name="xdg_toplevel" version="7">
+    <description summary="toplevel surface">
+      This interface defines an xdg_surface role which allows a surface to,
+      among other things, set window-like properties such as maximize,
+      fullscreen, and minimize, set application-specific metadata like title and
+      id, and well as trigger user interactive operations such as interactive
+      resize and move.
+
+      A xdg_toplevel by default is responsible for providing the full intended
+      visual representation of the toplevel, which depending on the window
+      state, may mean things like a title bar, window controls and drop shadow.
+
+      Unmapping an xdg_toplevel means that the surface cannot be shown
+      by the compositor until it is explicitly mapped again.
+      All active operations (e.g., move, resize) are canceled and all
+      attributes (e.g. title, state, stacking, ...) are discarded for
+      an xdg_toplevel surface when it is unmapped. The xdg_toplevel returns to
+      the state it had right after xdg_surface.get_toplevel. The client
+      can re-map the toplevel by performing a commit without any buffer
+      attached, waiting for a configure event and handling it as usual (see
+      xdg_surface description).
+
+      Attaching a null buffer to a toplevel unmaps the surface.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel">
+	This request destroys the role surface and unmaps the surface;
+	see "Unmapping" behavior in interface section for details.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="invalid_resize_edge" value="0" summary="provided value is
+        not a valid variant of the resize_edge enum"/>
+      <entry name="invalid_parent" value="1"
+        summary="invalid parent toplevel"/>
+      <entry name="invalid_size" value="2"
+	summary="client provided an invalid min or max size"/>
+    </enum>
+
+    <request name="set_parent">
+      <description summary="set the parent of this surface">
+	Set the "parent" of this surface. This surface should be stacked
+	above the parent surface and all other ancestor surfaces.
+
+	Parent surfaces should be set on dialogs, toolboxes, or other
+	"auxiliary" surfaces, so that the parent is raised when the dialog
+	is raised.
+
+	Setting a null parent for a child surface unsets its parent. Setting
+	a null parent for a surface which currently has no parent is a no-op.
+
+	Only mapped surfaces can have child surfaces. Setting a parent which
+	is not mapped is equivalent to setting a null parent. If a surface
+	becomes unmapped, its children's parent is set to the parent of
+	the now-unmapped surface. If the now-unmapped surface has no parent,
+	its children's parent is unset. If the now-unmapped surface becomes
+	mapped again, its parent-child relationship is not restored.
+
+	The parent toplevel must not be one of the child toplevel's
+	descendants, and the parent must be different from the child toplevel,
+	otherwise the invalid_parent protocol error is raised.
+      </description>
+      <arg name="parent" type="object" interface="xdg_toplevel" allow-null="true"/>
+    </request>
+
+    <request name="set_title">
+      <description summary="set surface title">
+	Set a short title for the surface.
+
+	This string may be used to identify the surface in a task bar,
+	window list, or other user interface elements provided by the
+	compositor.
+
+	The string must be encoded in UTF-8.
+      </description>
+      <arg name="title" type="string"/>
+    </request>
+
+    <request name="set_app_id">
+      <description summary="set application ID">
+	Set an application identifier for the surface.
+
+	The app ID identifies the general class of applications to which
+	the surface belongs. The compositor can use this to group multiple
+	surfaces together, or to determine how to launch a new application.
+
+	For D-Bus activatable applications, the app ID is used as the D-Bus
+	service name.
+
+	The compositor shell will try to group application surfaces together
+	by their app ID. As a best practice, it is suggested to select app
+	ID's that match the basename of the application's .desktop file.
+	For example, "org.freedesktop.FooViewer" where the .desktop file is
+	"org.freedesktop.FooViewer.desktop".
+
+	Like other properties, a set_app_id request can be sent after the
+	xdg_toplevel has been mapped to update the property.
+
+	See the desktop-entry specification [0] for more details on
+	application identifiers and how they relate to well-known D-Bus
+	names and .desktop files.
+
+	[0] https://standards.freedesktop.org/desktop-entry-spec/
+      </description>
+      <arg name="app_id" type="string"/>
+    </request>
+
+    <request name="show_window_menu">
+      <description summary="show the window menu">
+	Clients implementing client-side decorations might want to show
+	a context menu when right-clicking on the decorations, giving the
+	user a menu that they can use to maximize or minimize the window.
+
+	This request asks the compositor to pop up such a window menu at
+	the given position, relative to the local surface coordinates of
+	the parent surface. There are no guarantees as to what menu items
+	the window menu contains, or even if a window menu will be drawn
+	at all.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="x" type="int" summary="the x position to pop up the window menu at"/>
+      <arg name="y" type="int" summary="the y position to pop up the window menu at"/>
+    </request>
+
+    <request name="move">
+      <description summary="start an interactive move">
+	Start an interactive, user-driven move of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive move (touch,
+	pointer, etc).
+
+	The server may ignore move requests depending on the state of
+	the surface (e.g. fullscreen or maximized), or if the passed serial
+	is no longer valid.
+
+	If triggered, the surface will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the move. It is up to the
+	compositor to visually indicate that the move is taking place, such as
+	updating a pointer cursor, during the move. There is no guarantee
+	that the device focus will return when the move is completed.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <enum name="resize_edge">
+      <description summary="edge values for resizing">
+	These values are used to indicate which edge of a surface
+	is being dragged in a resize operation.
+      </description>
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="right" value="8"/>
+      <entry name="top_right" value="9"/>
+      <entry name="bottom_right" value="10"/>
+    </enum>
+
+    <request name="resize">
+      <description summary="start an interactive resize">
+	Start a user-driven, interactive resize of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive resize (touch,
+	pointer, etc).
+
+	The server may ignore resize requests depending on the state of
+	the surface (e.g. fullscreen or maximized).
+
+	If triggered, the client will receive configure events with the
+	"resize" state enum value and the expected sizes. See the "resize"
+	enum value for more details about what is required. The client
+	must also acknowledge configure events using "ack_configure". After
+	the resize is completed, the client will receive another "configure"
+	event without the resize state.
+
+	If triggered, the surface also will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the resize. It is up to the
+	compositor to visually indicate that the resize is taking place,
+	such as updating a pointer cursor, during the resize. There is no
+	guarantee that the device focus will return when the resize is
+	completed.
+
+	The edges parameter specifies how the surface should be resized, and
+	is one of the values of the resize_edge enum. Values not matching
+	a variant of the enum will cause the invalid_resize_edge protocol error.
+	The compositor may use this information to update the surface position
+	for example when dragging the top left corner. The compositor may also
+	use this information to adapt its behavior, e.g. choose an appropriate
+	cursor image.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="edges" type="uint" enum="resize_edge" summary="which edge or corner is being dragged"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of state on the surface">
+	The different state values used on the surface. This is designed for
+	state values like maximized, fullscreen. It is paired with the
+	configure event to ensure that both the client and the compositor
+	setting the state can be synchronized.
+
+	States set in this way are double-buffered, see wl_surface.commit.
+      </description>
+      <entry name="maximized" value="1" summary="the surface is maximized">
+	<description summary="the surface is maximized">
+	  The surface is maximized. The window geometry specified in the configure
+	  event must be obeyed by the client, or the xdg_wm_base.invalid_surface_state
+	  error is raised.
+
+	  The client should draw without shadow or other
+	  decoration outside of the window geometry.
+	</description>
+      </entry>
+      <entry name="fullscreen" value="2" summary="the surface is fullscreen">
+	<description summary="the surface is fullscreen">
+	  The surface is fullscreen. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it. For
+	  a surface to cover the whole fullscreened area, the geometry
+	  dimensions must be obeyed by the client. For more details, see
+	  xdg_toplevel.set_fullscreen.
+	</description>
+      </entry>
+      <entry name="resizing" value="3" summary="the surface is being resized">
+	<description summary="the surface is being resized">
+	  The surface is being resized. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it.
+	  Clients that have aspect ratio or cell sizing configuration can use
+	  a smaller size, however.
+	</description>
+      </entry>
+      <entry name="activated" value="4" summary="the surface is now activated">
+	<description summary="the surface is now activated">
+	  Client window decorations should be painted as if the window is
+	  active. Do not assume this means that the window actually has
+	  keyboard or pointer focus.
+	</description>
+      </entry>
+      <entry name="tiled_left" value="5" since="2">
+	<description summary="the surface’s left edge is tiled">
+	  The window is currently in a tiled layout and the left edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the left edge.
+	</description>
+      </entry>
+      <entry name="tiled_right" value="6" since="2">
+	<description summary="the surface’s right edge is tiled">
+	  The window is currently in a tiled layout and the right edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the right edge.
+	</description>
+      </entry>
+      <entry name="tiled_top" value="7" since="2">
+	<description summary="the surface’s top edge is tiled">
+	  The window is currently in a tiled layout and the top edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the top edge.
+	</description>
+      </entry>
+      <entry name="tiled_bottom" value="8" since="2">
+	<description summary="the surface’s bottom edge is tiled">
+	  The window is currently in a tiled layout and the bottom edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the bottom edge.
+	</description>
+      </entry>
+      <entry name="suspended" value="9" since="6">
+        <description summary="surface repaint is suspended">
+	  The surface is currently not ordinarily being repainted; for
+	  example because its content is occluded by another window, or its
+	  outputs are switched off due to screen locking.
+	</description>
+      </entry>
+      <entry name="constrained_left" value="10" since="7">
+	<description summary="the surface’s left edge is constrained">
+          The left edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_right" value="11" since="7">
+	<description summary="the surface’s right edge is constrained">
+          The right edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_top" value="12" since="7">
+	<description summary="the surface’s top edge is constrained">
+          The top edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_bottom" value="13" since="7">
+	<description summary="the surface’s bottom edge is constrained">
+          The bottom edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_max_size">
+      <description summary="set the maximum size">
+	Set a maximum size for the window.
+
+	The client can specify a maximum size so that the compositor does
+	not try to configure the window beyond this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered, see wl_surface.commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the maximum
+	size. The compositor may decide to ignore the values set by the
+	client and request a larger size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected maximum size in the given dimension.
+	As a result, a client wishing to reset the maximum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a maximum size to be smaller than the minimum size of
+	a surface is illegal and will result in an invalid_size error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width or height will result in a
+	invalid_size error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_min_size">
+      <description summary="set the minimum size">
+	Set a minimum size for the window.
+
+	The client can specify a minimum size so that the compositor does
+	not try to configure the window below this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered, see wl_surface.commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the minimum
+	size. The compositor may decide to ignore the values set by the
+	client and request a smaller size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected minimum size in the given dimension.
+	As a result, a client wishing to reset the minimum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a minimum size to be larger than the maximum size of
+	a surface is illegal and will result in an invalid_size error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width and height will result in a
+	invalid_size error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_maximized">
+      <description summary="maximize the window">
+	Maximize the surface.
+
+	After requesting that the surface should be maximized, the compositor
+	will respond by emitting a configure event. Whether this configure
+	actually sets the window maximized is subject to compositor policies.
+	The client must then update its content, drawing in the configured
+	state. The client must also acknowledge the configure when committing
+	the new content (see ack_configure).
+
+	It is up to the compositor to decide how and where to maximize the
+	surface, for example which output and what region of the screen should
+	be used.
+
+	If the surface was already maximized, the compositor will still emit
+	a configure event with the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="unmaximize the window">
+	Unmaximize the surface.
+
+	After requesting that the surface should be unmaximized, the compositor
+	will respond by emitting a configure event. Whether this actually
+	un-maximizes the window is subject to compositor policies.
+	If available and applicable, the compositor will include the window
+	geometry dimensions the window had prior to being maximized in the
+	configure event. The client must then update its content, drawing it in
+	the configured state. The client must also acknowledge the configure
+	when committing the new content (see ack_configure).
+
+	It is up to the compositor to position the surface after it was
+	unmaximized; usually the position the surface had before maximizing, if
+	applicable.
+
+	If the surface was already not maximized, the compositor will still
+	emit a configure event without the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="set_fullscreen">
+      <description summary="set the window as fullscreen on an output">
+	Make the surface fullscreen.
+
+	After requesting that the surface should be fullscreened, the
+	compositor will respond by emitting a configure event. Whether the
+	client is actually put into a fullscreen state is subject to compositor
+	policies. The client must also acknowledge the configure when
+	committing the new content (see ack_configure).
+
+	The output passed by the request indicates the client's preference as
+	to which display it should be set fullscreen on. If this value is NULL,
+	it's up to the compositor to choose which display will be used to map
+	this surface.
+
+	If the surface doesn't cover the whole output, the compositor will
+	position the surface in the center of the output and compensate with
+	with border fill covering the rest of the output. The content of the
+	border fill is undefined, but should be assumed to be in some way that
+	attempts to blend into the surrounding area (e.g. solid black).
+
+	If the fullscreened surface is not opaque, the compositor must make
+	sure that other screen content not part of the same surface tree (made
+	up of subsurfaces, popups or similarly coupled surfaces) are not
+	visible below the fullscreened surface.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen">
+      <description summary="unset the window as fullscreen">
+	Make the surface no longer fullscreen.
+
+	After requesting that the surface should be unfullscreened, the
+	compositor will respond by emitting a configure event.
+	Whether this actually removes the fullscreen state of the client is
+	subject to compositor policies.
+
+	Making a surface unfullscreen sets states for the surface based on the following:
+	* the state(s) it may have had before becoming fullscreen
+	* any state(s) decided by the compositor
+	* any state(s) requested by the client while the surface was fullscreen
+
+	The compositor may include the previous window geometry dimensions in
+	the configure event, if applicable.
+
+	The client must also acknowledge the configure when committing the new
+	content (see ack_configure).
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="set the window as minimized">
+	Request that the compositor minimize your surface. There is no
+	way to know if the surface is currently minimized, nor is there
+	any way to unset minimization on this surface.
+
+	If you are looking to throttle redrawing when minimized, please
+	instead use the wl_surface.frame event for this, as this will
+	also work with live previews on windows in Alt-Tab, Expose or
+	similar compositor features.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	This configure event asks the client to resize its toplevel surface or
+	to change its state. The configured state should not be applied
+	immediately. See xdg_surface.configure for details.
+
+	The width and height arguments specify a hint to the window
+	about how its surface should be resized in window geometry
+	coordinates. See set_window_geometry.
+
+	If the width or height arguments are zero, it means the client
+	should decide its own window dimension. This may happen when the
+	compositor needs to configure the state of the surface but doesn't
+	have any information about any previous or expected dimension.
+
+	The states listed in the event specify how the width/height
+	arguments should be interpreted, and possibly how it should be
+	drawn.
+
+	Clients must send an ack_configure in response to this event. See
+	xdg_surface.configure and xdg_surface.ack_configure for details.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="states" type="array"/>
+    </event>
+
+    <event name="close">
+      <description summary="surface wants to be closed">
+	The close event is sent by the compositor when the user
+	wants the surface to be closed. This should be equivalent to
+	the user clicking the close button in client-side decorations,
+	if your application has any.
+
+	This is only a request that the user intends to close the
+	window. The client may choose to ignore this request, or show
+	a dialog to ask the user to save their data, etc.
+      </description>
+    </event>
+
+    <!-- Version 4 additions -->
+
+    <event name="configure_bounds" since="4">
+      <description summary="recommended window geometry bounds">
+	The configure_bounds event may be sent prior to a xdg_toplevel.configure
+	event to communicate the bounds a window geometry size is recommended
+	to constrain to.
+
+	The passed width and height are in surface coordinate space. If width
+	and height are 0, it means bounds is unknown and equivalent to as if no
+	configure_bounds event was ever sent for this surface.
+
+	The bounds can for example correspond to the size of a monitor excluding
+	any panels or other shell components, so that a surface isn't created in
+	a way that it cannot fit.
+
+	The bounds may change at any point, and in such a case, a new
+	xdg_toplevel.configure_bounds will be sent, followed by
+	xdg_toplevel.configure and xdg_surface.configure.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+
+    <!-- Version 5 additions -->
+
+    <enum name="wm_capabilities" since="5">
+      <entry name="window_menu" value="1" summary="show_window_menu is available"/>
+      <entry name="maximize" value="2" summary="set_maximized and unset_maximized are available"/>
+      <entry name="fullscreen" value="3" summary="set_fullscreen and unset_fullscreen are available"/>
+      <entry name="minimize" value="4" summary="set_minimized is available"/>
+    </enum>
+
+    <event name="wm_capabilities" since="5">
+      <description summary="compositor capabilities">
+	This event advertises the capabilities supported by the compositor. If
+	a capability isn't supported, clients should hide or disable the UI
+	elements that expose this functionality. For instance, if the
+	compositor doesn't advertise support for minimized toplevels, a button
+	triggering the set_minimized request should not be displayed.
+
+	The compositor will ignore requests it doesn't support. For instance,
+	a compositor which doesn't advertise support for minimized will ignore
+	set_minimized requests.
+
+	Compositors must send this event once before the first
+	xdg_surface.configure event. When the capabilities change, compositors
+	must send this event again and then send an xdg_surface.configure
+	event.
+
+	The configured state should not be applied immediately. See
+	xdg_surface.configure for details.
+
+	The capabilities are sent as an array of 32-bit unsigned integers in
+	native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_popup" version="7">
+    <description summary="short-lived, popup surfaces for menus">
+      A popup surface is a short-lived, temporary surface. It can be used to
+      implement for example menus, popovers, tooltips and other similar user
+      interface concepts.
+
+      A popup can be made to take an explicit grab. See xdg_popup.grab for
+      details.
+
+      When the popup is dismissed, a popup_done event will be sent out, and at
+      the same time the surface will be unmapped. See the xdg_popup.popup_done
+      event for details.
+
+      Explicitly destroying the xdg_popup object will also dismiss the popup and
+      unmap the surface. Clients that want to dismiss the popup when another
+      surface of their own is clicked should dismiss the popup using the destroy
+      request.
+
+      A newly created xdg_popup will be stacked on top of all previously created
+      xdg_popup surfaces associated with the same xdg_toplevel.
+
+      The parent of an xdg_popup must be mapped (see the xdg_surface
+      description) before the xdg_popup itself.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_popup state to take effect.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_grab" value="0"
+	     summary="tried to grab after being mapped"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove xdg_popup interface">
+	This destroys the popup. Explicitly destroying the xdg_popup
+	object will also dismiss the popup, and unmap the surface.
+
+	If this xdg_popup is not the "topmost" popup, the
+	xdg_wm_base.not_the_topmost_popup protocol error will be sent.
+      </description>
+    </request>
+
+    <request name="grab">
+      <description summary="make the popup take an explicit grab">
+	This request makes the created popup take an explicit grab. An explicit
+	grab will be dismissed when the user dismisses the popup, or when the
+	client destroys the xdg_popup. This can be done by the user clicking
+	outside the surface, using the keyboard, or even locking the screen
+	through closing the lid or a timeout.
+
+	If the compositor denies the grab, the popup will be immediately
+	dismissed.
+
+	This request must be used in response to some sort of user action like a
+	button press, key press, or touch down event. The serial number of the
+	event should be passed as 'serial'.
+
+	The parent of a grabbing popup must either be an xdg_toplevel surface or
+	another xdg_popup with an explicit grab. If the parent is another
+	xdg_popup it means that the popups are nested, with this popup now being
+	the topmost popup.
+
+	Nested popups must be destroyed in the reverse order they were created
+	in, e.g. the only popup you are allowed to destroy at all times is the
+	topmost one.
+
+	When compositors choose to dismiss a popup, they may dismiss every
+	nested grabbing popup as well. When a compositor dismisses popups, it
+	will follow the same dismissing order as required from the client.
+
+	If the topmost grabbing popup is destroyed, the grab will be returned to
+	the parent of the popup, if that parent previously had an explicit grab.
+
+	If the parent is a grabbing popup which has already been dismissed, this
+	popup will be immediately dismissed. If the parent is a popup that did
+	not take an explicit grab, an error will be raised.
+
+	During a popup grab, the client owning the grab will receive pointer
+	and touch events for all their surfaces as normal (similar to an
+	"owner-events" grab in X11 parlance), while the top most grabbing popup
+	will always have keyboard focus.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="configure the popup surface">
+	This event asks the popup surface to configure itself given the
+	configuration. The configured state should not be applied immediately.
+	See xdg_surface.configure for details.
+
+	The x and y arguments represent the position the popup was placed at
+	given the xdg_positioner rule, relative to the upper left corner of the
+	window geometry of the parent surface.
+
+	For version 2 or older, the configure event for an xdg_popup is only
+	ever sent once for the initial configuration. Starting with version 3,
+	it may be sent again if the popup is setup with an xdg_positioner with
+	set_reactive requested, or in response to xdg_popup.reposition requests.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position relative to parent surface window geometry"/>
+      <arg name="y" type="int"
+	   summary="y position relative to parent surface window geometry"/>
+      <arg name="width" type="int" summary="window geometry width"/>
+      <arg name="height" type="int" summary="window geometry height"/>
+    </event>
+
+    <event name="popup_done">
+      <description summary="popup interaction is done">
+	The popup_done event is sent out when a popup is dismissed by the
+	compositor. The client should destroy the xdg_popup object at this
+	point.
+      </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="reposition" since="3">
+      <description summary="recalculate the popup's location">
+	Reposition an already-mapped popup. The popup will be placed given the
+	details in the passed xdg_positioner object, and a
+	xdg_popup.repositioned followed by xdg_popup.configure and
+	xdg_surface.configure will be emitted in response. Any parameters set
+	by the previous positioner will be discarded.
+
+	The passed token will be sent in the corresponding
+	xdg_popup.repositioned event. The new popup position will not take
+	effect until the corresponding configure event is acknowledged by the
+	client. See xdg_popup.repositioned for details. The token itself is
+	opaque, and has no other special meaning.
+
+	If multiple reposition requests are sent, the compositor may skip all
+	but the last one.
+
+	If the popup is repositioned in response to a configure event for its
+	parent, the client should send an xdg_positioner.set_parent_configure
+	and possibly an xdg_positioner.set_parent_size request to allow the
+	compositor to properly constrain the popup.
+
+	If the popup is repositioned together with a parent that is being
+	resized, but not in response to a configure event, the client should
+	send an xdg_positioner.set_parent_size request.
+      </description>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </request>
+
+    <event name="repositioned" since="3">
+      <description summary="signal the completion of a repositioned request">
+	The repositioned event is sent as part of a popup configuration
+	sequence, together with xdg_popup.configure and lastly
+	xdg_surface.configure to notify the completion of a reposition request.
+
+	The repositioned event is to notify about the completion of a
+	xdg_popup.reposition request. The token argument is the token passed
+	in the xdg_popup.reposition request.
+
+	Immediately after this event is emitted, xdg_popup.configure and
+	xdg_surface.configure will be sent with the updated size and position,
+	as well as a new configure serial.
+
+	The client should optionally update the content of the popup, but must
+	acknowledge the new popup configuration for the new position to take
+	effect. See xdg_surface.ack_configure for details.
+      </description>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </event>
+
+  </interface>
+</protocol>

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -84,6 +84,8 @@ void xdpw_session_destroy(struct xdpw_session *sess) {
 			xdpw_screencast_instance_destroy(cast);
 		}
 	}
+
 	free(sess->session_handle);
+	xdpw_input_capture_session_data_free(&sess->input_capture_data);
 	free(sess);
 }

--- a/src/input_capture/input_capture.c
+++ b/src/input_capture/input_capture.c
@@ -1,0 +1,1777 @@
+#include "input_capture.h"
+
+#include "xdpw.h"
+#include "logger.h"
+
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "pointer-constraints-unstable-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <stddef.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+
+static const char *INPUTCAPTURE_INTERFACE_NAME = "org.freedesktop.impl.portal.InputCapture";
+static const char *OBJECT_PATH_NAME = "/org/freedesktop/portal/desktop";
+
+/* --- static global data --- */
+
+static struct xdpw_input_capture_data interface_data = {
+  .xdpw_state = NULL,
+  .capabilities = 1 | 2,   // Keyboard | Pointer | Touchscreen (4), not implemented yet
+  .version = 1,
+  .bus = NULL,
+  .eis_context = NULL,
+  .wl_display = NULL,
+  .wl_registry = NULL,
+  .wl_compositor = NULL,
+  .wl_layer_shell = NULL,
+  .wl_seat = NULL,
+  .wl_pointer_constraints = NULL,
+  .wl_keyboard_shortcuts_manager = NULL,
+  .xkb_context = NULL,
+  .active_session = NULL
+};
+
+/* --- forward declarations --- */
+// dbus properties
+static int dbus_property_SupportedCapabilities(sd_bus *, const char *, const char *, const char *, sd_bus_message *, void *, sd_bus_error *);
+static int dbus_property_version(sd_bus *, const char *, const char *, const char *, sd_bus_message *, void *, sd_bus_error *);
+
+// dbus methods
+static int dbus_method_CreateSession(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_GetZones(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_SetPointerBarriers(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_Enable(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_Disable(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_Release(sd_bus_message *, void *, sd_bus_error *);
+static int dbus_method_ConnectToEIS(sd_bus_message *, void *, sd_bus_error *);
+
+// dbus signals
+static int dbus_signal_Activated(sd_bus *, struct xdpw_session *, uint32_t, double, double);
+static int dbus_signal_Deactivated(sd_bus *, struct xdpw_session *, double, double);
+static int dbus_signal_ZonesChanged(sd_bus *, const char *);
+static int dbus_signal_Disabled(sd_bus *, const char *) __attribute__((unused));
+
+// dbus helper functions
+static int dbus_helper_drain_dict(sd_bus_message *);
+static int dbus_helper_parse_CreateSession_options(sd_bus_message *, uint32_t *);
+static int dbus_helper_parse_Release_options(sd_bus_message *, uint32_t *, double *, double *);
+static char *dbus_helper_create_session_id(void);
+
+// eis helper functions
+static struct xdpw_session *eis_helper_find_session(const char *);
+static void eis_helper_handle_event(struct eis_event *);
+
+// wayland callback functions
+static void wayland_handle_layer_surface_configure(void *, struct zwlr_layer_surface_v1 *, uint32_t, uint32_t, uint32_t);
+static void wayland_handle_layer_surface_closed(void *, struct zwlr_layer_surface_v1 *);
+
+static void wayland_registry_global(void *, struct wl_registry *, uint32_t, const char *, uint32_t);
+static void wayland_registry_global_remove(void *, struct wl_registry *, uint32_t);
+static void cleanup_session_wayland(struct xdpw_session *);
+
+static void wayland_handle_pointer_enter(void *, struct wl_pointer *, uint32_t, struct wl_surface *, wl_fixed_t, wl_fixed_t);
+static void wayland_handle_pointer_leave(void *, struct wl_pointer *, uint32_t, struct wl_surface *);
+static void wayland_handle_pointer_motion(void *, struct wl_pointer *, uint32_t, wl_fixed_t, wl_fixed_t);
+static void wayland_handle_pointer_button(void *, struct wl_pointer *, uint32_t, uint32_t, uint32_t, uint32_t);
+static void wayland_handle_pointer_axis(void *, struct wl_pointer *, uint32_t, uint32_t, wl_fixed_t);
+
+static void wayland_handle_keyboard_keymap(void *, struct wl_keyboard *, uint32_t, int32_t, uint32_t);
+static void wayland_handle_keyboard_enter(void *, struct wl_keyboard *, uint32_t, struct wl_surface *, struct wl_array *);
+static void wayland_handle_keyboard_leave(void *, struct wl_keyboard *, uint32_t, struct wl_surface *);
+static void wayland_handle_keyboard_key(void *, struct wl_keyboard *, uint32_t, uint32_t, uint32_t, uint32_t);
+static void wayland_handle_keyboard_modifiers(void *, struct wl_keyboard *, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
+static void wayland_handle_keyboard_repeat(void *, struct wl_keyboard *, int32_t, int32_t);
+
+static void wayland_handle_seat_capabilities(void *, struct wl_seat *, uint32_t);
+static void wayland_handle_seat_name(void *, struct wl_seat *, const char *);
+
+static void wayland_handle_inhibitor_active(void *, struct zwp_keyboard_shortcuts_inhibitor_v1 *);
+static void wayland_handle_inhibitor_inactive(void *, struct zwp_keyboard_shortcuts_inhibitor_v1 *);
+
+static void wayland_handle_locked_pointer_locked(void *, struct zwp_locked_pointer_v1 *);
+static void wayland_handle_locked_pointer_unlocked(void *, struct zwp_locked_pointer_v1 *);
+
+static void output_handle_geometry(void *, struct wl_output *, int32_t, int32_t, int32_t, int32_t, int32_t, const char *, const char *, int32_t);
+static void output_handle_mode(void *, struct wl_output *, uint32_t, int32_t, int32_t, int32_t);
+static void output_handle_done(void *, struct wl_output *);
+static void output_handle_scale(void *, struct wl_output *, int32_t);
+
+static void free_barrier_list(struct xdpw_input_capture_barrier *);
+
+/* --- dbus vtable --- */
+static const sd_bus_vtable input_capture_vtable[] = {
+  SD_BUS_VTABLE_START(0),
+  SD_BUS_PROPERTY("SupportedCapabilities", "u", dbus_property_SupportedCapabilities, offsetof(struct xdpw_input_capture_data, capabilities), SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("version", "u", dbus_property_version, offsetof(struct xdpw_input_capture_data, version), SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_METHOD("CreateSession", "oossa{sv}", "ua{sv}", dbus_method_CreateSession, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("GetZones", "oosa{sv}", "ua{sv}", dbus_method_GetZones, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("SetPointerBarriers", "oosa{sv}aa{sv}u", "ua{sv}", dbus_method_SetPointerBarriers, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("Enable", "osa{sv}", "ua{sv}", dbus_method_Enable, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("Disable", "osa{sv}", "ua{sv}", dbus_method_Disable, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("Release", "osa{sv}", "ua{sv}", dbus_method_Release, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("ConnectToEIS", "osa{sv}", "h", dbus_method_ConnectToEIS, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_SIGNAL("Disabled", "oa{sv}", 0),
+  SD_BUS_SIGNAL("Activated", "oa{sv}", 0),
+  SD_BUS_SIGNAL("Deactivated", "oa{sv}", 0),
+  SD_BUS_SIGNAL("ZonesChanged", "oa{sv}", 0),
+  SD_BUS_VTABLE_END,
+};
+
+/* --- Wayland listeners --- */
+static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
+  .configure = wayland_handle_layer_surface_configure,
+  .closed = wayland_handle_layer_surface_closed
+};
+
+static const struct wl_registry_listener registry_listener = {
+  .global = wayland_registry_global,
+  .global_remove = wayland_registry_global_remove
+};
+
+static const struct wl_pointer_listener pointer_listener = {
+  .enter = wayland_handle_pointer_enter,
+  .leave = wayland_handle_pointer_leave,
+  .motion = wayland_handle_pointer_motion,
+  .button = wayland_handle_pointer_button,
+  .axis = wayland_handle_pointer_axis
+};
+
+static const struct wl_keyboard_listener keyboard_listener = {
+  .keymap = wayland_handle_keyboard_keymap,
+  .enter = wayland_handle_keyboard_enter,
+  .leave = wayland_handle_keyboard_leave,
+  .key = wayland_handle_keyboard_key,
+  .modifiers = wayland_handle_keyboard_modifiers,
+  .repeat_info = wayland_handle_keyboard_repeat
+};
+
+static const struct wl_seat_listener seat_listener = {
+  .capabilities = wayland_handle_seat_capabilities,
+  .name = wayland_handle_seat_name
+};
+
+static const struct zwp_keyboard_shortcuts_inhibitor_v1_listener inhibitor_listener = {
+  .active = wayland_handle_inhibitor_active,
+  .inactive = wayland_handle_inhibitor_inactive
+};
+
+static const struct zwp_locked_pointer_v1_listener locked_pointer_listener = {
+  .locked = wayland_handle_locked_pointer_locked,
+  .unlocked = wayland_handle_locked_pointer_unlocked
+};
+
+static const struct wl_output_listener output_listener = {
+  .geometry = output_handle_geometry,
+  .mode = output_handle_mode,
+  .done = output_handle_done,
+  .scale = output_handle_scale
+};
+
+static void free_barrier_list(struct xdpw_input_capture_barrier *list) {
+  struct xdpw_input_capture_barrier *b = list;
+  while (b) {
+    struct xdpw_input_capture_barrier *next = b->next;
+    free(b);
+    b = next;
+  }
+}
+
+void xdpw_input_capture_session_data_free(struct xdpw_input_capture_session_data *ic) {
+  if (!ic) return;
+  free_barrier_list(ic->barriers);
+}
+
+/*--------------------------------------------- Properties ------------------------------------------------------------*/
+static int dbus_property_SupportedCapabilities(sd_bus *bus, const char *path, const char *interface, 
+                                           const char *member, sd_bus_message *reply, 
+                                           void *userdata, sd_bus_error *ret_error) {
+  (void)bus;
+  (void)path;
+  (void)interface;
+  (void)member;
+  (void)userdata;
+  (void)ret_error;
+  return sd_bus_message_append(reply, "u", interface_data.capabilities);
+}
+
+static int dbus_property_version(sd_bus *bus, const char *path, const char *interface, 
+                                           const char *member, sd_bus_message *reply, 
+                                           void *userdata, sd_bus_error *ret_error) {
+  (void)bus;
+  (void)path;
+  (void)interface;
+  (void)member;
+  (void)userdata;
+  (void)ret_error;
+  return sd_bus_message_append(reply, "u", interface_data.version);
+}
+
+static int dbus_helper_drain_dict(sd_bus_message *m) {
+  int r = sd_bus_message_enter_container(m, 'a', "{sv}");
+  if (r < 0) {
+    logprint(ERROR, "Error entering container: %s", strerror(-r));
+    return r;
+  }
+  while (1) {
+    r = sd_bus_message_skip(m, "{sv}");
+    if (r < 0) {
+      logprint(ERROR, "Error skipping key-value pair in dictionary: %s", strerror(-r));
+      return r;
+    }
+    if (r == 0) break;
+  }
+  return sd_bus_message_exit_container(m);
+}
+
+static int dbus_helper_parse_CreateSession_options(sd_bus_message *m, uint32_t *capabilities) {
+  int r;
+
+  r = sd_bus_message_enter_container(m, 'a', "{sv}");
+  if (r < 0) {
+    logprint(ERROR, "Error entering container: %s", strerror(-r));
+    return r;
+  }
+
+  while (sd_bus_message_at_end(m, 0) == 0) {
+    const char *key;
+
+    r = sd_bus_message_enter_container(m, 'e', "sv");
+    if (r < 0) {
+      logprint(ERROR, "Failed to enter dict entry: %s", strerror(-r));
+      return r;
+    }
+
+    r = sd_bus_message_read(m, "s", &key);
+    if (r < 0) {
+      logprint(ERROR, "Failed to read dict key: %s", strerror(-r));
+      return r;
+    }
+
+    if (strcmp(key, "capabilities") == 0) {
+      r = sd_bus_message_read(m, "v", "u", capabilities);
+      if (r < 0) {
+        logprint(ERROR, "Failed to read capabilities's value: %s", strerror(-r));
+        return r;
+      }
+    }
+    else {
+      logprint(DEBUG, "Skipping unknown option: %s", key);
+      sd_bus_message_skip(m, "v");
+      if (r < 0) {
+        logprint(ERROR, "Failed to skip variant for key '%s': %s", key, strerror(-r));
+        return r;
+      }
+    }
+
+    r = sd_bus_message_exit_container(m);
+    if (r < 0) {
+      logprint(ERROR, "Failed to exit entry: %s", strerror(-r));
+      return r;
+    }
+  }
+
+  r = sd_bus_message_exit_container(m);
+  if (r < 0) {
+    logprint(ERROR, "Failed to exit container: %s", strerror(-r));
+    return r;
+  }
+
+  return 0;
+}
+
+static char *dbus_helper_create_session_id(void) {
+  static uint32_t session_counter = 0;
+  // generate a unique session_id string
+  // this is used by the client to identify the session in future calls
+  // we use a static counter combined with a random number for uniqueness
+  int size_needed = snprintf(NULL, 0, "%u_%u", getpid(), ++session_counter);
+  char *session_id = (char *)malloc(size_needed + 1);
+  if (!session_id) {
+    return NULL;
+  }
+  snprintf(session_id, size_needed + 1, "%u_%u", getpid(), session_counter);
+  return session_id;
+}
+
+static int dbus_method_CreateSession(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  (void)userdata;
+  int r;
+  // IN variables
+  const char *handle = NULL;          // object path for request object
+  const char *session_handle = NULL;  // object path for session object
+  const char *app_id = NULL;          // app id of the caller
+  const char *parent_window = NULL;   // window id
+  
+  // options vardict variables
+  uint32_t capabilities = 0;
+  
+  struct xdpw_session *context = NULL;
+  struct xdpw_request *request = NULL;
+  sd_bus_message *reply = NULL;
+
+  // parse IN arguments
+  r = sd_bus_message_read(m, "ooss", &handle, &session_handle, &app_id, &parent_window);
+  if (r < 0) {
+    logprint(ERROR, "Failed to parse arguments: %s", strerror(-r));
+    return r;
+  }
+
+  r = dbus_helper_parse_CreateSession_options(m, &capabilities);
+  if (r < 0) return r;
+
+  // validate capabilities 
+  capabilities &= interface_data.capabilities;
+  if (capabilities == 0) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotSupported", "Requested capabilities (%u) not supported by this portal", capabilities);
+    return -EOPNOTSUPP;
+  }
+
+  // create async request object
+  request = xdpw_request_create(sd_bus_message_get_bus(m), handle);
+  if (!request) return -ENOMEM;
+
+  // perform logic here
+  // TODO
+
+  // generate session context
+  
+  char *tmp = strdup(session_handle); // do not free it here, as xdpw_session_create takes ownership
+  if (!tmp) {
+    xdpw_request_destroy(request);
+    return -ENOMEM;
+  }
+  context = xdpw_session_create(interface_data.xdpw_state, sd_bus_message_get_bus(m), tmp);
+  if (!context) {
+    xdpw_request_destroy(request);
+    return -ENOMEM;
+  }
+  context->input_capture_data.capabilities = capabilities;
+
+  // // add context to global linked list
+  // context->input_capture_data->next = interface_data.session_list_head;
+  // interface_data.session_list_head = context;
+
+  logprint(DEBUG, "CreateSession call: created new session: %s", session_handle);
+
+  // construct the reply  
+  r = sd_bus_message_new_method_return(m , &reply);
+  if (r < 0) goto cleanup_request;
+
+  // append response code
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup_reply;
+
+  // append results dictionary
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_message_open_container(reply, 'e', "sv");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_append(reply, "s", "session_id");
+  if (r < 0) goto cleanup_reply;
+  
+  char *session_id = dbus_helper_create_session_id();
+  if (!session_id) goto cleanup_reply;
+  r = sd_bus_message_append(reply, "v", "s", session_id);
+  free(session_id);
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_message_open_container(reply, 'e', "sv");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_append(reply, "s", "capabilities");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_append(reply, "v", "u", context->input_capture_data.capabilities);
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+  
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+  if (r < 0) {
+    logprint(ERROR, "Failed to send CreateSession reply: %s", strerror(-r));
+  }
+
+cleanup_reply:
+  sd_bus_message_unref(reply);
+cleanup_request:
+  xdpw_request_destroy(request);
+  return r;
+}
+
+static int dbus_method_GetZones(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  int r;
+  const char *handle = NULL;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+
+  struct xdpw_session *context = NULL;
+  sd_bus_message *reply = NULL;
+
+  // get IN arguments
+  r = sd_bus_message_read(m, "oos", &handle, &session_handle, &app_id);
+  if (r < 0) return r;
+
+  // skip optional IN options of type a{sv}
+  r = dbus_helper_drain_dict(m);
+
+  context = eis_helper_find_session(session_handle);
+  if (!context) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "session_handle %s not found", session_handle);
+    return -ENOENT;
+  }
+
+  logprint(DEBUG, "GetZones: Reporting zone_set %u for session %s", context->input_capture_data.zone_set_id, session_handle);
+
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) goto cleanup;
+  
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_open_container(reply, 'e', "sv");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_append(reply, "s", "zone_set");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_append(reply, "v", "u", context->input_capture_data.zone_set_id);
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_open_container(reply, 'e', "sv");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_append(reply, "s", "zones");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_open_container(reply, 'v', "a(uuii)");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_open_container(reply, 'a', "(uuii)");
+  if (r < 0) goto cleanup;
+
+  struct xdpw_input_capture_output *iter;
+  wl_list_for_each(iter, &interface_data.output_list, link) {
+    if (iter->ready) {
+      r = sd_bus_message_append(
+        reply, 
+        "(uuii)",
+        iter->width,
+        iter->height,
+        iter->x,
+        iter->y
+      );
+      if (r < 0) {
+        logprint(ERROR, "GetZones: Failed to append zone: %s", strerror(-r));
+        goto cleanup;
+      }
+    }
+  }
+
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static int parse_and_store_barriers(sd_bus_message *m, struct xdpw_session *context, struct xdpw_input_capture_barrier **out_failed_barriers_head) {
+  int r;
+  struct xdpw_input_capture_barrier *new_barriers_head = NULL;
+  struct xdpw_input_capture_barrier *failed_barriers_head = NULL;
+
+  r = sd_bus_message_enter_container(m, 'a', "a{sv}");
+  if (r < 0) return r;
+
+  while ((r = sd_bus_message_enter_container(m, 'a', "{sv}")) > 0) {
+    uint32_t barrier_id = 0;
+    int32_t x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+    bool pos_found = false;
+    bool id_found = false;
+
+    while ((r = sd_bus_message_enter_container(m, 'e', "sv")) > 0) {
+      const char *key;
+      r = sd_bus_message_read(m, "s", &key);
+      if (r < 0) break;
+
+      if (strcmp(key, "barrier_id") == 0) {
+        sd_bus_message_read(m, "v", "u", &barrier_id);
+        id_found = true;
+      } else if (strcmp(key, "position") == 0) {
+        sd_bus_message_enter_container(m, 'v', "(iiii)");
+        sd_bus_message_enter_container(m, 'r', "iiii");
+        sd_bus_message_read(m, "i", &x1);
+        sd_bus_message_read(m, "i", &y1);
+        sd_bus_message_read(m, "i", &x2);
+        sd_bus_message_read(m, "i", &y2);
+        sd_bus_message_exit_container(m);
+        sd_bus_message_exit_container(m);
+        pos_found = true;
+      } else {
+        sd_bus_message_skip(m, "v");
+      }
+      sd_bus_message_exit_container(m);
+    }
+    if (r < 0) goto cleanup_error;
+
+    bool failed = false;
+    // must have id and position
+    if (!id_found || !pos_found) failed = true;
+    // id must be non zero
+    if (barrier_id == 0) failed = true;
+    // must be vertical or horizontal
+    if (x1 != x2 && y1 != y2) failed = true;
+    // must have length
+    if (x1 == x2 && y1 == y2) failed = true;
+
+    struct xdpw_input_capture_barrier *node = (struct xdpw_input_capture_barrier *)calloc(1, sizeof(struct xdpw_input_capture_barrier));
+    if (!node) {
+      r = -ENOMEM;
+      goto cleanup_error;
+    }
+
+    node->id = barrier_id;
+
+    if (failed) {
+      // add to failed list
+      node->next = failed_barriers_head;
+      failed_barriers_head = node;
+    } else {
+      node->x1 = x1; node->y1 = y1;
+      node->x2 = x2; node->y2 = y2;
+      node->next = new_barriers_head;
+      new_barriers_head = node;
+      logprint(DEBUG, "  -> Stored valid barrier ID %u (%i, %i to %i, %i)", barrier_id, x1, y1, x2, y2);
+    }
+    sd_bus_message_exit_container(m);
+  }
+  if (r < 0) goto cleanup_error;
+  r = sd_bus_message_exit_container(m);
+  if (r < 0) goto cleanup_error;
+
+  free_barrier_list(context->input_capture_data.barriers);
+  context->input_capture_data.barriers = new_barriers_head;
+
+  *out_failed_barriers_head = failed_barriers_head;
+
+  return 0;
+
+cleanup_error:
+  free_barrier_list(new_barriers_head);
+  free_barrier_list(failed_barriers_head);
+  return r;
+}
+
+static int dbus_method_SetPointerBarriers(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  int r;
+  const char *handle = NULL;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+  uint32_t zone_set = 0;
+
+  struct xdpw_session *context = NULL;
+  struct xdpw_input_capture_barrier *failed_barriers_list = NULL;
+  sd_bus_message *reply = NULL;
+
+  // parse IN arguments
+  r = sd_bus_message_read(m, "oos", &handle, &session_handle, &app_id);
+  if (r < 0) {
+    logprint(ERROR, "SetPointerBarriers: failed to read arguments: %s", strerror(-r));
+    return r;
+  }
+
+  r = dbus_helper_drain_dict(m);
+  if (r < 0) return r;
+
+  // validate session
+  context = eis_helper_find_session(session_handle);
+  if (!context) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "Session not found: %s", session_handle);
+    return -ENOENT;
+  }
+
+  r = parse_and_store_barriers(m, context, &failed_barriers_list);
+  if (r < 0) {
+    sd_bus_error_setf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to parse barriers array: %s", strerror(-r));
+    return r;
+  }
+
+  r = sd_bus_message_read(m, "u", &zone_set);
+  if (r < 0) {
+    free_barrier_list(failed_barriers_list);
+    return r;
+  }
+
+  if (zone_set != context->input_capture_data.zone_set_id) {
+    logprint(WARN, "SetPointerbarriers: zone set id mismatch (client: %u, server: %u)", zone_set, context->input_capture_data.zone_set_id);
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "Zone set id mismatch (client: %u, server: %u)", zone_set, context->input_capture_data.zone_set_id);
+    
+    free_barrier_list(context->input_capture_data.barriers);
+    context->input_capture_data.barriers = NULL;
+
+    free_barrier_list(failed_barriers_list);
+    return -EINVAL;
+  }
+
+  logprint(DEBUG, "SetPointerBarriers: successfully updated barriers for session %s", session_handle);
+
+  // construct reply
+  // signature: ua{sv}
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) {
+    free_barrier_list(failed_barriers_list);
+    return r;
+  }
+
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+
+  if (failed_barriers_list) {
+    r = sd_bus_message_open_container(reply, 'e', "sv");
+    if (r < 0) goto cleanup;
+    r = sd_bus_message_append(reply, "s", "failed_barriers");
+    if (r < 0) goto cleanup;
+    r = sd_bus_message_open_container(reply, 'v', "au");
+    if (r < 0) goto cleanup;
+    r = sd_bus_message_open_container(reply, 'a', "u");
+    if (r < 0) goto cleanup;
+  
+    struct xdpw_input_capture_barrier *iter = failed_barriers_list;
+    while (iter) {
+      sd_bus_message_append(reply, "u", iter->id);
+      iter = iter->next;
+    }
+    r = sd_bus_message_close_container(reply);
+    if (r < 0) goto cleanup;
+    r = sd_bus_message_close_container(reply);
+    if (r < 0) goto cleanup;
+    r = sd_bus_message_close_container(reply);
+    if (r < 0) goto cleanup;
+  }
+
+  r = sd_bus_message_close_container(reply); 
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup:
+  sd_bus_message_unref(reply);
+  free_barrier_list(failed_barriers_list);
+  return r;
+}
+
+static int dbus_method_Enable(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  int r;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+  sd_bus_message *reply = NULL;
+  struct xdpw_session *context = NULL;
+
+  r = sd_bus_message_read(m, "os", &session_handle, &app_id);
+  if (r < 0) return r;
+
+  r = dbus_helper_drain_dict(m);
+  if (r < 0) return r;
+
+  context = eis_helper_find_session(session_handle);
+  if (!context) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "session_handle %s not found", session_handle);
+    return -ENOENT;
+  }
+  
+  if (context->input_capture_data.enabled) {
+    logprint(DEBUG, "Session %s already enabled", session_handle);
+    goto send_reply;
+  }
+
+  // exclusivity check - only one active session at a time
+  if (interface_data.active_session != NULL) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.Failed", "Another input capture is already active");
+    return -EBUSY;
+  }
+
+  if (!interface_data.wl_compositor || !interface_data.wl_layer_shell ||
+      !interface_data.wl_seat || !interface_data.wl_pointer_constraints ||
+      !interface_data.wl_keyboard_shortcuts_manager) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotSupported", "Compositor is missing required wayland protocols");
+    return -EOPNOTSUPP;
+  }
+
+  logprint(DEBUG, "Enabling Input Capture for session %s (app: %s)", session_handle, app_id);
+
+
+  if (context->input_capture_data.capabilities & 2) {
+    context->input_capture_data.wl_pointer = wl_seat_get_pointer(interface_data.wl_seat);
+    if (context->input_capture_data.wl_pointer) wl_pointer_add_listener(context->input_capture_data.wl_pointer, &pointer_listener, context);
+  }
+  if (context->input_capture_data.capabilities & 1) {
+    context->input_capture_data.wl_keyboard = wl_seat_get_keyboard(interface_data.wl_seat);
+    if (context->input_capture_data.wl_keyboard) wl_keyboard_add_listener(context->input_capture_data.wl_keyboard, &keyboard_listener, context);
+  }
+  
+  context->input_capture_data.wl_surface = wl_compositor_create_surface(interface_data.wl_compositor);
+  if (!context->input_capture_data.wl_surface) {
+    cleanup_session_wayland(context);
+    return -ENOMEM;
+  }
+  
+  context->input_capture_data.wl_layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+    interface_data.wl_layer_shell,
+    context->input_capture_data.wl_surface,
+    NULL, // no output, global
+    ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
+    "input-capture-portal"
+  );
+  if (!context->input_capture_data.wl_layer_surface) {
+    cleanup_session_wayland(context);
+    return -ENOENT;
+  }
+
+  zwlr_layer_surface_v1_add_listener(context->input_capture_data.wl_layer_surface, &layer_surface_listener, context);
+  zwlr_layer_surface_v1_set_anchor(context->input_capture_data.wl_layer_surface, ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);  
+  zwlr_layer_surface_v1_set_size(context->input_capture_data.wl_layer_surface, 0, 0);
+
+  if (context->input_capture_data.capabilities & 1) {
+    zwlr_layer_surface_v1_set_keyboard_interactivity(context->input_capture_data.wl_layer_surface, ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE);
+  }
+  
+  wl_surface_commit(context->input_capture_data.wl_surface);
+
+  if (context->input_capture_data.capabilities & 1) {
+    context->input_capture_data.wl_keyboard_inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+      interface_data.wl_keyboard_shortcuts_manager,
+      context->input_capture_data.wl_surface,
+      interface_data.wl_seat
+    );
+    if (context->input_capture_data.wl_keyboard_inhibitor) {
+      zwp_keyboard_shortcuts_inhibitor_v1_add_listener(
+        context->input_capture_data.wl_keyboard_inhibitor,
+        &inhibitor_listener,
+        context
+      );
+    }
+  }
+  
+  wl_display_roundtrip(interface_data.wl_display);
+  
+  context->input_capture_data.enabled = true;
+  interface_data.active_session = context;
+
+  double cursor_x = wl_fixed_to_double(context->input_capture_data.last_pointer_x);
+  double cursor_y = wl_fixed_to_double(context->input_capture_data.last_pointer_y);
+
+  dbus_signal_Activated(interface_data.bus, context, 0, cursor_x, cursor_y);
+
+  if (context->input_capture_data.device) {
+    eis_device_start_emulating(context->input_capture_data.device, context->input_capture_data.activation_id);
+  }
+
+send_reply:
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) return r;
+
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+  
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup_reply:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static void cleanup_session_wayland(struct xdpw_session *context) {
+  if (!context) return;
+
+  logprint(DEBUG, "cleaning up wayland resources for session %s", (context->session_handle) ? context->session_handle : "UNKNOWN");
+
+  if (context->input_capture_data.wl_keyboard_inhibitor) {
+    zwp_keyboard_shortcuts_inhibitor_v1_destroy(context->input_capture_data.wl_keyboard_inhibitor);
+    context->input_capture_data.wl_keyboard_inhibitor = NULL;
+  }
+  if (context->input_capture_data.wl_locked_pointer) {
+    zwp_locked_pointer_v1_destroy(context->input_capture_data.wl_locked_pointer);
+    context->input_capture_data.wl_locked_pointer = NULL;
+  }
+  if (context->input_capture_data.wl_layer_surface) {
+    zwlr_layer_surface_v1_destroy(context->input_capture_data.wl_layer_surface);
+    context->input_capture_data.wl_layer_surface = NULL;
+  }
+  if (context->input_capture_data.wl_surface) {
+    wl_surface_destroy(context->input_capture_data.wl_surface);
+    context->input_capture_data.wl_surface = NULL;
+  }
+  if (context->input_capture_data.wl_pointer) {
+    wl_pointer_destroy(context->input_capture_data.wl_pointer);
+    context->input_capture_data.wl_pointer = NULL;
+  }
+  if (context->input_capture_data.wl_keyboard) {
+    wl_keyboard_destroy(context->input_capture_data.wl_keyboard);
+    context->input_capture_data.wl_keyboard = NULL;
+  }
+  if (context->input_capture_data.xkb_state) {
+    xkb_state_unref(context->input_capture_data.xkb_state);
+    context->input_capture_data.xkb_state = NULL;
+  }
+  if(context->input_capture_data.xkb_keymap) {
+    xkb_keymap_unref(context->input_capture_data.xkb_keymap);
+    context->input_capture_data.xkb_keymap = NULL;
+  }
+  if (interface_data.wl_display) {
+    wl_display_flush(interface_data.wl_display);
+  }
+}
+
+static int dbus_method_Disable(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+int r;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+  sd_bus_message *reply = NULL;
+  struct xdpw_session *context = NULL;
+
+  r = sd_bus_message_read(m, "os", &session_handle, &app_id);
+  if (r < 0) return r;
+
+  r = dbus_helper_drain_dict(m);
+  if (r < 0) return r;
+
+  context = eis_helper_find_session(session_handle);
+  if (!context) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "session_handle %s not found", session_handle);
+    return -ENOENT;
+  }
+
+  logprint(DEBUG, "Disabling Input Capture for session %s (app: %s)", session_handle, app_id);
+  
+  if (!context->input_capture_data.enabled) {
+    logprint(DEBUG, "Session %s is already disabled", session_handle);
+    goto send_reply;
+  }
+
+  double final_x = wl_fixed_to_double(context->input_capture_data.last_pointer_x);
+  double final_y = wl_fixed_to_double(context->input_capture_data.last_pointer_y);
+
+  cleanup_session_wayland(context);
+  context->input_capture_data.enabled = false;
+
+  if (interface_data.active_session == context) {
+    interface_data.active_session = NULL;
+  }
+
+  if (context->input_capture_data.device) {
+    eis_device_stop_emulating(context->input_capture_data.device);
+  }
+
+  dbus_signal_Deactivated(interface_data.bus, context, final_x, final_y);
+
+send_reply:
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) return r;
+
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup_reply:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static int dbus_helper_parse_Release_options(sd_bus_message *m, uint32_t *activation_id, double *cursor_position_x, double *cursor_position_y) {
+  int r;
+
+  r = sd_bus_message_enter_container(m, 'a', "{sv}");
+  if (r < 0) {
+    logprint(ERROR, "Error entering container: %s", strerror(-r));
+    return r;
+  }
+
+  while (sd_bus_message_at_end(m, 0) == 0) {
+    const char *key;
+
+    r = sd_bus_message_enter_container(m, 'e', "sv");
+    if (r < 0) {
+      logprint(ERROR, "Failed to enter dict entry: %s", strerror(-r));
+      return r;
+    }
+
+    r = sd_bus_message_read(m, "s", &key);
+    if (r < 0) {
+      logprint(ERROR, "Failed to read dict key: %s", strerror(-r));
+      return r;
+    }
+
+    if (strcmp(key, "activation_id") == 0) {
+      r = sd_bus_message_read(m, "v", "u", activation_id);
+      if (r < 0) {
+        logprint(ERROR, "Failed to read activation_id's value: %s", strerror(-r));
+        return r;
+      }
+    } else if (strcmp(key, "cursor_position") == 0) {
+      r = sd_bus_message_enter_container(m, 'v', "(dd)");
+      if (r < 0) return r;
+      
+      r = sd_bus_message_enter_container(m, 'r', "dd");
+      if (r >= 0) {
+        r = sd_bus_message_read(m, "d", cursor_position_x);
+        r = sd_bus_message_read(m, "d", cursor_position_y);
+
+        sd_bus_message_exit_container(m);
+        if (r < 0) return r;
+
+      }
+    } else {
+      logprint(DEBUG, "Skipping unknown option: %s", key);
+      sd_bus_message_skip(m, "v");
+      if (r < 0) {
+        logprint(ERROR, "Failed to skip variant for key '%s': %s", key, strerror(-r));
+        return r;
+      }
+    }
+
+    r = sd_bus_message_exit_container(m);
+    if (r < 0) {
+      logprint(ERROR, "Failed to exit entry: %s", strerror(-r));
+      return r;
+    }
+  }
+
+  r = sd_bus_message_exit_container(m);
+  if (r < 0) {
+    logprint(ERROR, "Failed to exit container: %s", strerror(-r));
+    return r;
+  }
+
+  return 0;
+}
+
+static int dbus_method_Release(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  int r;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+  uint32_t activation_id = 0;
+  double cursor_position_x = 0, cursor_position_y = 0;
+  sd_bus_message *reply = NULL;
+
+  r = sd_bus_message_read(m, "os", &session_handle, &app_id);
+  if (r < 0) {
+    logprint(ERROR, "Error reading object path: %s", strerror(-r));
+    return r;
+  }
+
+  r = dbus_helper_parse_Release_options(m, &activation_id, &cursor_position_x, &cursor_position_y);
+  if (r < 0) {
+    logprint(ERROR, "Error draining dictionary: %s", strerror(-r));
+    return r;
+  }
+
+  struct xdpw_session *context = eis_helper_find_session(session_handle);
+  if (!context) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "%s session_handle not found", session_handle);
+    return -ENOENT;
+  }
+
+  logprint(DEBUG, "Release call with session_handle %s", session_handle);
+
+  if (context->input_capture_data.enabled) {
+    cleanup_session_wayland(context);
+    context->input_capture_data.enabled = false;
+
+    if (interface_data.active_session == context) interface_data.active_session = NULL;
+  }
+
+  if (context->input_capture_data.device) eis_device_stop_emulating(context->input_capture_data.device);
+
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) return r;
+
+  r = sd_bus_message_append(reply, "u", 0U);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto cleanup_reply;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto cleanup_reply;
+
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup_reply:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static int dbus_method_ConnectToEIS(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+  int r;
+  const char *session_handle = NULL;
+  const char *app_id = NULL;
+  struct xdpw_session *context = NULL;
+  sd_bus_message *reply = NULL;
+
+  r = sd_bus_message_read(m, "os", &session_handle, &app_id);
+  if (r < 0) return r;
+
+  r = dbus_helper_drain_dict(m);
+  if (r < 0) return r;
+
+  context = eis_helper_find_session(session_handle);
+  if (!context) {
+    logprint(ERROR, "Could not find session at %s session_handle", session_handle);
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.NotFound", "Session handle '%s' not found", session_handle);
+    return -ENOENT;
+  }
+  
+  logprint(DEBUG, "ConnectToEIS: Setting up EIS socket for session %s (app: %s)", session_handle, app_id);
+
+  int client_fd = eis_backend_fd_add_client(interface_data.eis_context);
+  if (client_fd < 0) {
+    sd_bus_error_setf(ret_error, "org.freedesktop.portal.Error.Failed", "Failed to add EIS client: %s", strerror(-client_fd));
+    return -EOPNOTSUPP;
+  }
+
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) {
+    close(client_fd);
+    return r;
+  }
+
+  r = sd_bus_message_append(reply, "h", client_fd);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+
+cleanup:
+  sd_bus_message_unref(reply);
+  close(client_fd);
+
+  return r;
+}
+
+static int dbus_signal_Disabled(sd_bus *bus, const char *session_handle)
+{
+  int r;
+  sd_bus_message *signal = NULL;
+
+  logprint(DEBUG, "Emitting Disabled signal for session %s", session_handle);
+
+  r = sd_bus_message_new_signal(bus, &signal, OBJECT_PATH_NAME, INPUTCAPTURE_INTERFACE_NAME, "Disabled");
+  if (r < 0) {
+    logprint(ERROR, "Error creating Disabled signal: %s", strerror(-r));
+    return r;
+  }
+
+  r = sd_bus_message_append(signal, "o", session_handle);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(signal, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_close_container(signal);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(bus, signal, NULL);
+  if (r < 0) {
+    logprint(ERROR, "Failed to send Disabled signal: %s", strerror(-r));
+  }
+cleanup:
+  sd_bus_message_unref(signal);
+  return r;
+}
+
+static int dbus_signal_Activated(sd_bus *bus, struct xdpw_session *context, uint32_t barrier_id, double cursor_x, double cursor_y)
+{
+  int r;
+  sd_bus_message *signal = NULL;
+
+  context->input_capture_data.activation_id++;
+
+  logprint(DEBUG, "Emitting Activated signal for session %s (ID: %u, xdpw_input_capture_barrier %u)", context->session_handle, context->input_capture_data.activation_id, barrier_id);
+
+  r = sd_bus_message_new_signal(bus, &signal, OBJECT_PATH_NAME, INPUTCAPTURE_INTERFACE_NAME, "Activated");
+  if (r < 0) {
+    logprint(ERROR, "Error creating Activated signal: %s", strerror(-r));
+    return r;
+  }
+
+  r = sd_bus_message_append(signal, "o", context->session_handle);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(signal, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+
+  sd_bus_message_open_container(signal, 'e', "sv");
+  sd_bus_message_append(signal, "s", "activation_id");
+  sd_bus_message_open_container(signal, 'v', "u");
+  sd_bus_message_append(signal, "u", context->input_capture_data.activation_id);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+
+  sd_bus_message_open_container(signal, 'e', "sv");
+  sd_bus_message_append(signal, "s", "cursor_position");
+
+  sd_bus_message_open_container(signal, 'v', "(dd)");
+  sd_bus_message_open_container(signal, 'r', "dd");
+  sd_bus_message_append(signal, "d", cursor_x);
+  sd_bus_message_append(signal, "d", cursor_y);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+
+  // only append if a valid barrier_id was passed
+  if (barrier_id > 0) {
+    sd_bus_message_open_container(signal, 'e', "sv");
+    sd_bus_message_append(signal, "s", "barrier_id");
+    sd_bus_message_open_container(signal, 'v', "u");
+    sd_bus_message_append(signal, "u", barrier_id);
+    sd_bus_message_close_container(signal);
+    sd_bus_message_close_container(signal);
+  }
+  
+  r = sd_bus_message_close_container(signal);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(bus, signal, NULL);
+  if (r < 0) {
+    logprint(ERROR, "Failed to send Activated signal: %s", strerror(-r));
+  }
+cleanup:
+  sd_bus_message_unref(signal);
+  return r;
+}
+
+static int dbus_signal_Deactivated(sd_bus *bus, struct xdpw_session *context, double cursor_x, double cursor_y)
+{
+  int r;
+  sd_bus_message *signal = NULL;
+  
+  logprint(DEBUG, "Emitting Deactivated signal for session %s (last ID: %u)", context->session_handle, context->input_capture_data.activation_id);
+
+  r = sd_bus_message_new_signal(bus, &signal, OBJECT_PATH_NAME, INPUTCAPTURE_INTERFACE_NAME, "Deactivated");
+  if (r < 0) {
+    logprint(ERROR, "Failed to create Deactivated signal: %s", strerror(-r));
+    return r;
+  }
+
+  r = sd_bus_message_append(signal, "o", context->session_handle);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(signal, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+
+  sd_bus_message_open_container(signal, 'e', "sv");
+  sd_bus_message_append(signal, "s", "activation_id");
+  sd_bus_message_open_container(signal, 'v', "u");
+  sd_bus_message_append(signal, "u", context->input_capture_data.activation_id);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+
+  sd_bus_message_open_container(signal, 'e', "sv");
+  sd_bus_message_append(signal, "s", "cursor_position");
+
+  sd_bus_message_open_container(signal, 'v', "(dd)");
+  sd_bus_message_open_container(signal, 'r', "dd");
+  sd_bus_message_append(signal, "d", cursor_x);
+  sd_bus_message_append(signal, "d", cursor_y);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+  sd_bus_message_close_container(signal);
+
+  r = sd_bus_message_close_container(signal);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(bus, signal, NULL);
+  if (r < 0) {
+    logprint(ERROR, "Failed to send Deactivated signal: %s", strerror(-r));
+  }
+
+cleanup:
+  sd_bus_message_unref(signal);
+  return r;
+}
+
+static int dbus_signal_ZonesChanged(sd_bus *bus, const char *session_handle)
+{
+  int r;
+  sd_bus_message *signal = NULL;
+
+  logprint(DEBUG, "Emitting ZonesChanged signal for session %s", session_handle);
+
+  r = sd_bus_message_new_signal(bus, &signal, OBJECT_PATH_NAME, INPUTCAPTURE_INTERFACE_NAME, "ZonesChanged");
+  if (r < 0) {
+    logprint(ERROR, "Failed to create ZonesChanged signal: %s", strerror(-r));
+    return r;
+  }
+
+  r = sd_bus_message_append(signal, "o", session_handle);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_message_open_container(signal, 'a', "{sv}");
+  if (r < 0) goto cleanup;
+  r = sd_bus_message_close_container(signal);
+  if (r < 0) goto cleanup;
+
+  r = sd_bus_send(bus, signal, NULL);
+  if (r < 0) {
+    logprint(ERROR, "Failed to send ZonesChanged signal: %s", strerror(-r));
+  }
+cleanup:
+  sd_bus_message_unref(signal);
+  return r;
+}
+
+// static struct xdpw_input_capture_session_data* eis_helper_find_session(const char *session_path) {
+//   struct xdpw_input_capture_session_data *iter = interface_data.session_list_head;
+//   while (iter) {
+//     if (strcmp(iter->session_handle, session_path) == 0) {
+//       return iter;
+//     }
+//     iter = iter->next;
+//   }
+//   return NULL;
+// }
+
+static struct xdpw_session *eis_helper_find_session(const char *session_path) {
+  struct xdpw_session *session;
+  wl_list_for_each(session, &(interface_data.xdpw_state->xdpw_sessions), link) {
+    if (strcmp(session->session_handle, session_path) == 0) return session;
+  }
+  return NULL;
+}
+
+static void eis_helper_handle_event(struct eis_event *event) {
+  logprint(DEBUG, "EIS Event: %s", eis_event_type_to_string(eis_event_get_type(event)));
+
+  switch (eis_event_get_type(event)) {
+    case EIS_EVENT_CLIENT_CONNECT: {
+      struct eis_client *client = eis_event_get_client(event);
+      logprint(DEBUG, "New EIS client connected");
+      eis_client_connect(client);
+      break;
+    }
+    case EIS_EVENT_CLIENT_DISCONNECT: {
+      struct eis_client *client = eis_event_get_client(event);
+      struct xdpw_session *context = (struct xdpw_session *)eis_client_get_user_data(client);
+      if (context) {
+        context->input_capture_data.device = NULL;
+        logprint(DEBUG, "EIS client disconnected (session_path: %s)", context->session_handle);
+      }
+      break;
+    }
+    case EIS_EVENT_SEAT_BIND: {
+      struct eis_seat *seat = eis_event_get_seat(event);
+      struct eis_client *client = eis_seat_get_client(seat);
+
+      const char *seat_name = eis_seat_get_name(seat);
+      logprint(DEBUG, "EIS client bound seat: %s", seat_name);
+
+      struct xdpw_session *context = eis_helper_find_session(seat_name);
+      if (!context) {
+        logprint(ERROR, "EIS Error: unknown session_path used as seat name: %s", seat_name);
+        eis_client_disconnect(client);
+        return;
+      }
+
+      logprint(DEBUG, "Linking EIS client to session %s", context->session_handle);
+      eis_client_set_user_data(client, context);
+
+      if (context->input_capture_data.capabilities & 1) eis_seat_configure_capability(seat, EIS_DEVICE_CAP_KEYBOARD);
+      if (context->input_capture_data.capabilities & 2) eis_seat_configure_capability(seat, EIS_DEVICE_CAP_POINTER);
+      if (context->input_capture_data.capabilities & 4) eis_seat_configure_capability(seat, EIS_DEVICE_CAP_TOUCH);
+      eis_seat_add(seat);
+
+      logprint(DEBUG, "Creating new virtual device for session %s", context->session_handle);
+
+      struct eis_device *device = eis_seat_new_device(seat);
+      eis_device_configure_name(device, "Portal Virtual Input");
+      eis_device_configure_type(device, EIS_DEVICE_TYPE_VIRTUAL);
+      
+      if (context->input_capture_data.capabilities & 1) eis_device_configure_capability(device, EIS_DEVICE_CAP_KEYBOARD);
+      if (context->input_capture_data.capabilities & 2) eis_device_configure_capability(device, EIS_DEVICE_CAP_POINTER);
+      if (context->input_capture_data.capabilities & 4) eis_device_configure_capability(device, EIS_DEVICE_CAP_TOUCH);
+      
+      eis_device_add(device);
+      eis_device_resume(device);
+
+      context->input_capture_data.device = device;
+      break;
+    }
+    default: 
+      logprint(TRACE, "EIS event not handled: %s", eis_event_type_to_string(eis_event_get_type(event)));
+      break;
+  }
+}
+
+static void wayland_registry_global(void *data, struct wl_registry *registry,
+                                    uint32_t name, const char *interface, uint32_t version) {
+  struct xdpw_input_capture_data *d = (struct xdpw_input_capture_data *)data;
+
+  if (strcmp(interface, wl_compositor_interface.name) == 0) {
+    d->wl_compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 4);
+    logprint(DEBUG, "Wayland: bound wl_compositor");
+  } else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
+    d->wl_layer_shell = wl_registry_bind(registry, name, &zwlr_layer_shell_v1_interface, 1);
+    logprint(DEBUG, "Wayland: bound zwlr_layer_shell_v1");
+  } else if (strcmp(interface, wl_seat_interface.name) == 0) {
+    d->wl_seat = wl_registry_bind(registry, name, &wl_seat_interface, 7);
+    wl_seat_add_listener(d->wl_seat, &seat_listener, d);
+    logprint(DEBUG, "Wayland: bound wl_seat");
+  } else if (strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0) {
+    d->wl_pointer_constraints = wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, 1);
+    logprint(DEBUG, "Wayland: boudn zwp_pointer_constraints_v1");
+  } else if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+    d->wl_keyboard_shortcuts_manager = wl_registry_bind(registry, name, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
+    logprint(DEBUG, "Wayland: bound zwp_keyboard_shortcuts_inhibit_manager_v1");
+  } else if (strcmp(interface, wl_output_interface.name) == 0) {
+    struct xdpw_input_capture_output *output = calloc(1, sizeof(struct xdpw_input_capture_output));
+    if (!output) return;
+    output->data = d;
+    output->name = name;
+    output->wl_output = wl_registry_bind(registry, name, &wl_output_interface, 3);
+    wl_output_add_listener(output->wl_output, &output_listener, output);
+    wl_list_insert(&d->output_list, &output->link);
+    logprint(DEBUG, "Wayland: bound wl_output %u", name);
+  }
+}
+
+static void wayland_registry_global_remove(void *data, struct wl_registry *registry, uint32_t name) {
+  struct xdpw_input_capture_data *d = (struct xdpw_input_capture_data *)data;
+  struct xdpw_input_capture_output *iter, *tmp;
+
+  wl_list_for_each_safe(iter, tmp, &d->output_list, link) {
+    if (iter->name == name) {
+      wl_list_remove(&iter->link);
+      wl_output_destroy(iter->wl_output);
+      free(iter);
+      logprint(DEBUG, "Wayland: output %u removed", name);
+      return;
+    }
+  }
+
+}
+
+static void wayland_handle_seat_capabilities(void *data, struct wl_seat *seat, uint32_t capabilities) {
+  logprint(DEBUG, "Wayland: Seat capabilities changed");
+}
+
+static void wayland_handle_seat_name(void *data, struct wl_seat *seat, const char *name) {
+  logprint(DEBUG, "Wayland: Seat name changed");
+}
+
+static void wayland_handle_inhibitor_active(void *data, struct zwp_keyboard_shortcuts_inhibitor_v1 *inhibitor) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  logprint(DEBUG, "Wayland: Keyboard inhibitor ACTIVE for session %s", context->session_handle);
+
+  if (interface_data.active_session == context) {
+    double cursor_x = wl_fixed_to_double(context->input_capture_data.last_pointer_x);
+    double cursor_y = wl_fixed_to_double(context->input_capture_data.last_pointer_y);
+
+    dbus_signal_Activated(interface_data.bus, context, 0, cursor_x, cursor_y);
+
+    if (context->input_capture_data.device) {
+      eis_device_start_emulating(context->input_capture_data.device, context->input_capture_data.activation_id);
+    }
+  }
+}
+
+static void wayland_handle_inhibitor_inactive(void *data, struct zwp_keyboard_shortcuts_inhibitor_v1 *inhibitor) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  logprint(DEBUG, "Wayland: keyboard inhibitor INACTIVE for session %s", context->session_handle);
+  
+  if (context->input_capture_data.enabled) {
+    double final_x = wl_fixed_to_double(context->input_capture_data.last_pointer_x);
+    double final_y = wl_fixed_to_double(context->input_capture_data.last_pointer_y);
+
+    if (context->input_capture_data.device) {
+      eis_device_stop_emulating(context->input_capture_data.device);
+    }
+    
+    dbus_signal_Deactivated(interface_data.bus, context, final_x, final_y);
+  }
+}
+
+static void wayland_handle_layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *surface, uint32_t serial, uint32_t w, uint32_t h) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  logprint(DEBUG, "Wayland: layer surface configured: %ux%u", w, h);
+  zwlr_layer_surface_v1_ack_configure(surface, serial);
+  wl_surface_commit(context->input_capture_data.wl_surface);
+}
+
+static void wayland_handle_layer_surface_closed(void *data, struct zwlr_layer_surface_v1 *surface) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  logprint(WARN, "Wayland: Layer surface closed unexpectedly! Disabling session ");
+  cleanup_session_wayland(context);
+  context->input_capture_data.enabled = false;
+  interface_data.active_session = NULL;
+  // dbus_signal_Deactivated(interface_data.bus, context->session_handle);
+}
+
+static void wayland_handle_pointer_enter(void *data, struct wl_pointer *ptr, uint32_t serial,
+                                        struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  logprint(DEBUG, "Wayland pointer entered surface");
+
+  if (interface_data.wl_pointer_constraints && !context->input_capture_data.wl_locked_pointer) {
+    context->input_capture_data.wl_locked_pointer = zwp_pointer_constraints_v1_lock_pointer(
+      interface_data.wl_pointer_constraints,
+      surface,
+      context->input_capture_data.wl_pointer,
+      NULL,
+      ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT
+    );
+    zwp_locked_pointer_v1_add_listener(context->input_capture_data.wl_locked_pointer, &locked_pointer_listener, context);
+  }
+
+  // store initial position for delta calculation
+  context->input_capture_data.last_pointer_x = sx;
+  context->input_capture_data.last_pointer_y = sy;
+}
+
+static void wayland_handle_pointer_leave(void *data, struct wl_pointer *ptr, uint32_t serial, struct wl_surface *surface) {
+  logprint(DEBUG, "Wayland: pointer left surface");
+}
+
+static void wayland_handle_pointer_motion(void *data, struct wl_pointer *ptr, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (!context->input_capture_data.device) return;
+
+  logprint(DEBUG, "POINTER MOTION");
+
+  // calculate delta from last position
+  wl_fixed_t dx = sx - context->input_capture_data.last_pointer_x;
+  wl_fixed_t dy = sy - context->input_capture_data.last_pointer_y;
+
+  eis_device_pointer_motion(context->input_capture_data.device, wl_fixed_to_double(dx), wl_fixed_to_double(dy));
+
+  context->input_capture_data.last_pointer_x = sx;
+  context->input_capture_data.last_pointer_y = sy;
+}
+
+static void wayland_handle_pointer_button(void *data, struct wl_pointer *ptr, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (!context->input_capture_data.device) return;
+
+  eis_device_button_button(context->input_capture_data.device, button, (state == WL_POINTER_BUTTON_STATE_PRESSED));
+}
+
+static void wayland_handle_pointer_axis(void *data, struct wl_pointer *ptr, uint32_t time, uint32_t axis, wl_fixed_t value) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (!context->input_capture_data.device) return;
+
+  double dx = 0.0;
+  double dy = 0.0;
+
+  if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
+    dy = wl_fixed_to_double(value);
+  } else if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
+    dx = wl_fixed_to_double(value);
+  } else {
+    return;
+  }
+  eis_device_scroll_delta(context->input_capture_data.device, dx, dy);
+}
+
+static void wayland_handle_keyboard_keymap(void *data, struct wl_keyboard *kbd, uint32_t format, int32_t fd, uint32_t size) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
+    close(fd);
+    return;
+  }
+  logprint(DEBUG, "Wayland: Got keymap (fd: %d, size %u)", fd, size);
+
+  int eis_fd = -1;
+  if (context->input_capture_data.device) {
+    eis_fd = dup(fd);
+    if (eis_fd < 0) {
+      logprint(ERROR, "Wayland: failed to dup keymap fd: %s", strerror(errno));
+    }
+  }
+
+  char *map_shm = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+  if (map_shm == MAP_FAILED) {
+    logprint(ERROR, "Wayland: mmap failed for keymap: %s", strerror(errno));
+    close(fd);
+    if (eis_fd >= 0) close(eis_fd);
+    return;
+  }
+
+  if (context->input_capture_data.xkb_keymap) xkb_keymap_unref(context->input_capture_data.xkb_keymap);
+  if (context->input_capture_data.xkb_state) xkb_state_unref(context->input_capture_data.xkb_state);
+
+  context->input_capture_data.xkb_keymap = xkb_keymap_new_from_string(
+    interface_data.xkb_context,
+    map_shm,
+    XKB_KEYMAP_FORMAT_TEXT_V1,
+    XKB_KEYMAP_COMPILE_NO_FLAGS
+  );
+  munmap(map_shm, size);
+  close(fd);
+
+  if (!context->input_capture_data.xkb_keymap) {
+    logprint(ERROR, "Wayland: failed to create xkb_keymap from string");
+    if (eis_fd >= 0) close(eis_fd);
+    return;
+  }
+
+  context->input_capture_data.xkb_state = xkb_state_new(context->input_capture_data.xkb_keymap);
+  if (!context->input_capture_data.xkb_state) {
+    logprint(ERROR, "Wayland: failed to create xkb_state");
+  }
+
+  if (context->input_capture_data.device && eis_fd >= 0) {
+    logprint(DEBUG, "EIS: forwarding keymap fd %d", eis_fd);
+    struct eis_keymap *keymap = eis_device_new_keymap(context->input_capture_data.device, EIS_KEYMAP_TYPE_XKB, eis_fd, size);
+    if (keymap) {
+      eis_keymap_add(keymap);
+      eis_keymap_unref(keymap);
+    } else {
+      logprint(ERROR, "EIS: failed to create new keymap");
+      close(eis_fd);
+    }
+  } else if (eis_fd >= 0) {
+    close(eis_fd);
+  }
+}
+
+static void wayland_handle_keyboard_enter(void *data, struct wl_keyboard *kbd, uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {
+  logprint(DEBUG, "Wayland: keyboard focus acquired");
+}
+
+static void wayland_handle_keyboard_leave(void *data, struct wl_keyboard *kbd, uint32_t serial, struct wl_surface *surface) {
+  logprint(DEBUG, "Wayland: keyboard focus lost");
+}
+
+static void wayland_handle_keyboard_key(void *data, struct wl_keyboard *kbd, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (!context->input_capture_data.device) return;
+  eis_device_keyboard_key(context->input_capture_data.device, key, (state == WL_KEYBOARD_KEY_STATE_PRESSED));
+}
+
+static void wayland_handle_keyboard_modifiers(void *data, struct wl_keyboard *kbd, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) {
+  struct xdpw_session *context = (struct xdpw_session *)data;
+  if (!context->input_capture_data.device) return;
+  if (context->input_capture_data.xkb_state) {
+    xkb_state_update_mask(context->input_capture_data.xkb_state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
+  }
+  eis_device_keyboard_send_xkb_modifiers(context->input_capture_data.device, mods_depressed, mods_latched, mods_locked, group);
+}
+
+static void wayland_handle_keyboard_repeat(void *data, struct wl_keyboard *kbd, int32_t, int32_t) {
+  // wayland handles repeats by sending multiple .key events
+}
+
+static void wayland_handle_locked_pointer_locked(void *data, struct zwp_locked_pointer_v1 *locked_pointer) {
+  logprint(DEBUG, "Wayland: Pointer locked");
+}
+static void wayland_handle_locked_pointer_unlocked(void *data, struct zwp_locked_pointer_v1 *locked_pointer) {
+  logprint(DEBUG, "Wayland: Pointer unlocked");
+}
+
+static void output_handle_geometry(void *data, struct wl_output *wl_output, int32_t x, int32_t y, int32_t phys_w, int32_t phys_h, int32_t subpixel, const char *make, const char *model, int32_t transform) {
+  struct xdpw_input_capture_output *output = (struct xdpw_input_capture_output *)data;
+  output->x = x;
+  output->y = y;
+}
+
+static void output_handle_mode(void * data, struct wl_output *wl_output, uint32_t flags, int32_t width, int32_t height, int32_t refresh) {
+  struct xdpw_input_capture_output *output = (struct xdpw_input_capture_output *)data;
+  if (flags & WL_OUTPUT_MODE_CURRENT) {
+    output->width = width;
+    output->height = height;
+  }
+}
+
+// static void output_handle_done(void *data, struct wl_output *wl_output) {
+//   struct xdpw_input_capture_output *output = (struct xdpw_input_capture_output *)data;
+//   output->ready = true;
+//   logprint(DEBUG, "Wayland: output %u is ready (%dx%d @ %d,%d)", output->name, output->width, output->height, output->x, output->y);
+
+//   struct xdpw_input_capture_session_data *iter = output->data->session_list_head;
+//   while (iter) {
+//     if (iter->enabled) {
+//       // invalidate the clients current zone_set_id and notify them
+//       // the spec says to increment by a "sensible amount"
+//       if (iter->zone_set_id == 0) iter->zone_set_id = 1;
+//       else iter->zone_set_id++;
+//       dbus_signal_ZonesChanged(output->data->bus, iter->session_handle);
+//     }
+//     iter = iter->next;
+//   }
+// }
+
+static void output_handle_done(void *data, struct wl_output *wl_output) {
+  struct xdpw_input_capture_output *output = (struct xdpw_input_capture_output *)data;
+  
+  output->ready = true;
+  logprint(DEBUG, "Wayland: output %u is ready (%dx%d @ %d,%d)", output->name, output->width, output->height, output->x, output->y);
+
+  struct xdpw_session *iter = NULL;
+  wl_list_for_each(iter, &(interface_data.xdpw_state->xdpw_sessions), link) {
+    struct xdpw_input_capture_session_data *ic_data = &(iter->input_capture_data);
+
+    if (ic_data->enabled) {
+      if (ic_data->zone_set_id == 0) ic_data->zone_set_id = 1;
+      else ic_data->zone_set_id++;
+      dbus_signal_ZonesChanged(interface_data.bus, iter->session_handle);
+    }
+  }
+}
+
+static void output_handle_scale(void *data, struct wl_output *wl_output, int32_t factor) {
+  // Not needed for this portal
+}
+
+/* --- public api functions --- */
+int xdpw_input_capture_init(struct xdpw_state *state) {
+  int r;
+  struct eis *eis_context = NULL;
+
+  wl_list_init(&interface_data.output_list);
+
+  // use the existing bus and display from the main state
+  interface_data.xdpw_state = state;
+  interface_data.bus = state->bus;
+  interface_data.wl_display = state->wl_display;
+
+  interface_data.xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!interface_data.xkb_context) {
+    logprint(ERROR, "Failed to create xkb_context");
+    r = -EIO;
+    goto cleanup_wayland;
+  }
+
+  interface_data.wl_registry = wl_display_get_registry(interface_data.wl_display);
+  wl_registry_add_listener(interface_data.wl_registry, &registry_listener, &interface_data);
+  wl_display_roundtrip(interface_data.wl_display);
+
+  // check if we got essential globals
+  if ( !interface_data.wl_compositor || !interface_data.wl_layer_shell ||
+    !interface_data.wl_seat || !interface_data.wl_pointer_constraints ||
+    !interface_data.wl_keyboard_shortcuts_manager ) {
+    logprint(ERROR, "Compositor is missing required wayland protocols:");
+    if (!interface_data.wl_compositor) logprint(ERROR, "  - wl_compositor is missing");
+    if (!interface_data.wl_layer_shell) logprint(ERROR, " - zwlr_layer_shell_v1 is missing (are you on sway/hyprland?)");
+    if (!interface_data.wl_seat) logprint(ERROR, "  - wl_seat is missing");
+    if (!interface_data.wl_pointer_constraints) logprint(ERROR, " - zwp_pointer_constraints_v1 is missing");
+    if (!interface_data.wl_keyboard_shortcuts_manager) logprint(ERROR, "  - zwp_keyboard_shortcuts_inhibit_manager_v1 is missing");
+    r = -EPROTONOSUPPORT;
+    goto cleanup_wayland;
+  }
+
+  eis_context = eis_new(&interface_data);
+  if (!eis_context) {
+    logprint(ERROR, "Failed to create EIS context");
+    r = -ENOMEM;
+    goto cleanup_wayland;
+  }
+
+  r = eis_setup_backend_fd(eis_context);
+  if (r < 0) {
+    logprint(ERROR, "Failed to setup EIS FD backend", strerror(-r));
+    goto cleanup_eis;
+  }
+
+  logprint(INFO, "Eis server listening");
+
+  int eis_fd = eis_get_fd(eis_context);
+  if (eis_fd < 0) {
+    logprint(ERROR, "Failed to get EIS fd, got: %d", eis_fd);
+    r = EINVAL;
+    goto cleanup_eis;
+  }
+
+  r = sd_bus_add_object_vtable(
+    interface_data.bus,
+    NULL,
+    OBJECT_PATH_NAME,
+    INPUTCAPTURE_INTERFACE_NAME,
+    input_capture_vtable,
+    &interface_data
+  );
+
+  if (r < 0) {
+    logprint(ERROR, "Failed to add D-BUS vtable: %s", strerror(-r));
+    goto cleanup_eis;
+  }
+
+	interface_data.eis_context = eis_context;
+  state->input_capture.libei_fd = eis_fd;
+
+  return 0;
+cleanup_eis:
+  eis_unref(eis_context);
+cleanup_wayland:
+  if (interface_data.xkb_context) xkb_context_unref(interface_data.xkb_context);
+  if (interface_data.wl_seat) wl_seat_destroy(interface_data.wl_seat);
+  if (interface_data.wl_pointer_constraints) zwp_pointer_constraints_v1_destroy(interface_data.wl_pointer_constraints);
+  if (interface_data.wl_keyboard_shortcuts_manager) zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(interface_data.wl_keyboard_shortcuts_manager);
+  if (interface_data.wl_layer_shell) zwlr_layer_shell_v1_destroy(interface_data.wl_layer_shell);
+  if (interface_data.wl_compositor) wl_compositor_destroy(interface_data.wl_compositor);
+  if (interface_data.wl_registry) wl_registry_destroy(interface_data.wl_registry);
+
+  return r;
+}
+
+void xdpw_input_capture_destroy(void) {
+  if (!interface_data.bus) return;
+
+  logprint(DEBUG, "InputCapture portal shutting down");
+
+  struct xdpw_input_capture_output *iter, *tmp;
+  wl_list_for_each_safe(iter, tmp, &interface_data.output_list, link) {
+    wl_list_remove(&iter->link);
+    wl_output_destroy(iter->wl_output);
+    free(iter);
+  }
+
+  if (interface_data.eis_context) eis_unref(interface_data.eis_context);
+  if (interface_data.xkb_context) xkb_context_unref(interface_data.xkb_context);
+  if (interface_data.wl_seat) wl_seat_destroy(interface_data.wl_seat);
+  if (interface_data.wl_pointer_constraints) zwp_pointer_constraints_v1_destroy(interface_data.wl_pointer_constraints);
+  if (interface_data.wl_keyboard_shortcuts_manager) zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(interface_data.wl_keyboard_shortcuts_manager);
+  if (interface_data.wl_layer_shell) zwlr_layer_shell_v1_destroy(interface_data.wl_layer_shell);
+  if (interface_data.wl_compositor) wl_compositor_destroy(interface_data.wl_compositor);
+  if (interface_data.wl_registry) wl_registry_destroy(interface_data.wl_registry);
+}
+
+void xdpw_input_capture_dispatch_eis(struct xdpw_state *state) {
+  struct eis *eis = interface_data.eis_context;
+  if (!eis) return;
+
+  eis_dispatch(eis);
+  struct eis_event *event;
+  while ((event = eis_get_event(eis))) {
+    eis_helper_handle_event(event);
+    eis_event_unref(event);
+  }
+}

--- a/wlr.portal
+++ b/wlr.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wlr
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
+Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.InputCapture;
 UseIn=wlroots;sway;Wayfire;river;phosh;Hyprland;


### PR DESCRIPTION
Hey all,

I'm submitting the implementation for the org.freedesktop.portal.InputCapture feature, which addresses Issue #278. This is the code that lets applications (like remote desktop tools or VMs) securely grab and inject keyboard/mouse input on wlroots compositors.

How It Works:
The core idea is to use libei (Event Interception) for the data stream and several wlroots protocols to handle the necessary input lockdown:

- An invisible layer-shell surface takes focus to capture all events.

- Pointer constraints lock the cursor inside.

- Keyboard inhibitors prevent system shortcuts (like Mod+Enter) from breaking the session.

Testing Environment: Functional success was verified by using the deskflow client communicating over the network with this build running in a dedicated Sway VM.

I know this feature has been requested for a while. I'm looking forward to getting this merged and seeing it in action. Please let me know if you spot anything that needs attention!

Cheers, 
Anton