### PR TITLE
Rename "dmenu" choosers to "menu"

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -40,7 +40,7 @@ enum xdpw_chooser_types {
   XDPW_CHOOSER_DEFAULT,
   XDPW_CHOOSER_NONE,
   XDPW_CHOOSER_SIMPLE,
-  XDPW_CHOOSER_DMENU,
+  XDPW_CHOOSER_MENU,
 };
 
 struct xdpw_chooser {

--- a/src/screencast/chooser.c
+++ b/src/screencast/chooser.c
@@ -112,7 +112,7 @@ static char *read_chooser_out(FILE *f) {
 }
 
 static char *get_output_label(struct xdpw_wlr_output *output, enum xdpw_chooser_types chooser_type) {
-	if (chooser_type == XDPW_CHOOSER_DMENU) {
+	if (chooser_type == XDPW_CHOOSER_MENU) {
 		return format_str("Monitor: %s %s", output->name, output->description);
 	} else {
 		return format_str("Monitor: %s", output->name);
@@ -120,7 +120,7 @@ static char *get_output_label(struct xdpw_wlr_output *output, enum xdpw_chooser_
 }
 
 static char *get_toplevel_label(struct xdpw_toplevel *toplevel, enum xdpw_chooser_types chooser_type) {
-	if (chooser_type == XDPW_CHOOSER_DMENU) {
+	if (chooser_type == XDPW_CHOOSER_MENU) {
 		return format_str("Window: %s (%s)", toplevel->title, toplevel->identifier);
 	} else {
 		return format_str("Window: %s", toplevel->identifier);
@@ -140,7 +140,7 @@ static bool wlr_chooser(const struct xdpw_chooser *chooser,
 	}
 
 	switch (chooser->type) {
-	case XDPW_CHOOSER_DMENU:
+	case XDPW_CHOOSER_MENU:
 		if (type_mask & MONITOR) {
 			struct xdpw_wlr_output *out;
 			wl_list_for_each(out, &ctx->output_list, link) {
@@ -222,11 +222,11 @@ static bool wlr_chooser_default(struct xdpw_screencast_context *ctx, struct xdpw
 
 	const struct xdpw_chooser default_chooser[] = {
 		{XDPW_CHOOSER_SIMPLE, "slurp -f 'Monitor: %o' -or"},
-		{XDPW_CHOOSER_DMENU, "wmenu -p 'Select a source to share:' -l 10"},
-		{XDPW_CHOOSER_DMENU, "wofi -d -n --prompt='Select a source to share:'"},
-		{XDPW_CHOOSER_DMENU, "rofi -dmenu -p 'Select a source to share:'"},
-		{XDPW_CHOOSER_DMENU, "bemenu --prompt='Select a source to share:'"},
-		{XDPW_CHOOSER_DMENU, "mew -l 10 -p 'Select a source to share:'"},
+		{XDPW_CHOOSER_MENU, "wmenu -p 'Select a source to share:' -l 10"},
+		{XDPW_CHOOSER_MENU, "wofi -d -n --prompt='Select a source to share:'"},
+		{XDPW_CHOOSER_MENU, "rofi -dmenu -p 'Select a source to share:'"},
+		{XDPW_CHOOSER_MENU, "bemenu --prompt='Select a source to share:'"},
+		{XDPW_CHOOSER_MENU, "mew -l 10 -p 'Select a source to share:'"},
 	};
 
 	size_t N = sizeof(default_chooser)/sizeof(default_chooser[0]);
@@ -259,7 +259,7 @@ bool xdpw_wlr_target_chooser(struct xdpw_screencast_context *ctx, struct xdpw_sc
 			target->output = xdpw_wlr_output_first(&ctx->output_list);
 		}
 		return target->output != NULL;
-	case XDPW_CHOOSER_DMENU:
+	case XDPW_CHOOSER_MENU:
 	case XDPW_CHOOSER_SIMPLE:;
 		if (!ctx->state->config->screencast_conf.chooser_cmd) {
 			logprint(ERROR, "wlroots: no chooser given");

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -410,8 +410,9 @@ enum xdpw_chooser_types get_chooser_type(const char *chooser_type) {
 		return XDPW_CHOOSER_NONE;
 	} else if (strcmp(chooser_type, "simple") == 0) {
 		return XDPW_CHOOSER_SIMPLE;
-	} else if (strcmp(chooser_type, "dmenu") == 0) {
-		return XDPW_CHOOSER_DMENU;
+	} else if (strcmp(chooser_type, "menu") == 0 || strcmp(chooser_type, "dmenu") == 0) {
+		// "dmenu" is for compatibility with xdg-desktop-portal ≤ v0.8.1
+		return XDPW_CHOOSER_MENU;
 	}
 	fprintf(stderr, "Could not understand chooser type %s\n", chooser_type);
 	exit(1);
@@ -425,8 +426,8 @@ const char *chooser_type_str(enum xdpw_chooser_types chooser_type) {
 		return "none";
 	case XDPW_CHOOSER_SIMPLE:
 		return "simple";
-	case XDPW_CHOOSER_DMENU:
-		return "dmenu";
+	case XDPW_CHOOSER_MENU:
+		return "menu";
 	}
 	fprintf(stderr, "Could not find chooser type %d\n", chooser_type);
 	abort();

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -67,7 +67,7 @@ These options need to be placed under the **[screencast]** section.
 	  (slurp, wmenu, wofi, rofi, bemenu, mew) and will fallback to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
-	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
+	- simple, menu: xdpw will launch the chooser given by **chooser_cmd**. For more details
 	  see **OUTPUT CHOOSER**.
 
 **force_mod_linear** = _bool_
@@ -88,14 +88,14 @@ The chooser can be any program or script with the following behaviour:
    - For simple choosers:
      - The prefix "Monitor: " followed by the name of a valid output as given by **wayland-info**(1).
      - The prefix "Window: " followed by the ext-foreign-toplevel-list-v1 identifier as given by **lswt**(1).
-   - For dmenu choosers: one of the lines provided via stdin.
+   - For menu choosers: one of the lines provided via stdin.
    Everything else will be handled as declined by the user.
 - To signal that the user has declined screencast, the chooser should exit without
   anything on stdout.
 
 Supported types of choosers via the **chooser_type** option:
 - simple: the chooser is just called without anything further on stdin.
-- dmenu: the chooser receives a newline separated list (dmenu style) of outputs on stdin.
+- menu: the chooser receives a newline separated list (dmenu style) of outputs on stdin.
 
 # SEE ALSO
 


### PR DESCRIPTION
"dmenu" is the name of a particular piece of software. Any kind of newline-delimited menu is supported here.

Should this be named "text-menu", to leave some room for more complicated menus with structured input?