### PR TITLE
include fuzzel as chooser

### DIFF
--- a/src/screencast/chooser.c
+++ b/src/screencast/chooser.c
@@ -227,6 +227,7 @@ static bool wlr_chooser_default(struct xdpw_screencast_context *ctx, struct xdpw
 		{XDPW_CHOOSER_DMENU, "rofi -dmenu -p 'Select a source to share:'"},
 		{XDPW_CHOOSER_DMENU, "bemenu --prompt='Select a source to share:'"},
 		{XDPW_CHOOSER_DMENU, "mew -l 10 -p 'Select a source to share:'"},
+		{XDPW_CHOOSER_DMENU, "fuzzel -d -l 10 -p 'Select a source to share:'"},
 	};
 
 	size_t N = sizeof(default_chooser)/sizeof(default_chooser[0]);

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -64,7 +64,7 @@ These options need to be placed under the **[screencast]** section.
 
 	The supported types are:
 	- default: xdpw will try to use the first chooser found in the list of hardcoded choosers
-	  (slurp, wmenu, wofi, rofi, bemenu, mew) and will fallback to an arbitrary output if none of those were found.
+	  (slurp, wmenu, wofi, rofi, bemenu, mew, fuzzel) and will fallback to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
 	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details


### PR DESCRIPTION
This adds fuzzel (https://codeberg.org/dnkl/fuzzel) to the list of choosers