### PR TITLE
Revert "screenshot: announce version 1"

### DIFF
--- a/include/screenshot_common.h
+++ b/include/screenshot_common.h
@@ -1,6 +1,6 @@
 #ifndef SCREENSHOT_COMMON_H
 #define SCREENSHOT_COMMON_H
 
-#define XDP_SHOT_PROTO_VER 1
+#define XDP_SHOT_PROTO_VER 2
 
 #endif


### PR DESCRIPTION
This reverts #259.

The Screenshot portal will ask users for permission the first time an applications tries to take a non-interactive screenshot (see https://github.com/flatpak/xdg-desktop-portal/commit/c8274173f7d127f1d7e39e8b5bcaf7f0ee751f48), but only if the backend announces that it supports version 2 of the portal.

In #231 this was implemented, but in #259 the version was changed to 1 with this rationale:

> Since we don't support the permission store yet, we should only announce support for version 1

However, the permissions store is fully implemented in xdg-desktop-portal. xdg-desktop-portal-wlr doesn't have to do anything to support it. So I don't really understand this.

Admittedly, the UI in xdg-desktop-portal is not great (e.g. https://github.com/flatpak/xdg-desktop-portal/issues/1593), but from a security perspective that is still better than allowing any application to take screenshots without user interaction.

I am not 100% what to do about the `permission_store_checked` option. AFAIU, current versions of xdg-desktop-portal will always set this to true (or block the request before it reaches the backend). However, older versions and alternative implementations might not implement those checks. We could force the screenshot to be interactive unless `permission_store_checked` is set.