### PR TITLE
screencast: default to 60fps when target has no native refresh rate

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -65,6 +65,9 @@ void xdpw_screencast_instance_init(struct xdpw_screencast_context *ctx,
 	if (target->type == MONITOR) {
 		output_framerate = target->output->framerate;
 	}
+	if (output_framerate == 0) {
+		output_framerate = 60;
+	}
 
 	cast->ctx = ctx;
 	cast->target = target;


### PR DESCRIPTION
This fixes an an issue with window-specific screensharing

Window (toplevel) capture targets don't have a native refresh rate, unlike monitor outputs. This left output_framerate at 0, which produced an invalid maxFramerate range (0/1 to 0/1) in the PipeWire EnumFormat params. Consumers like Firefox could never negotiate a framerate, so format negotiation failed immediately and the PipeWire link went to error state.

Fall back to 60fps when the target has no known refresh rate. This also guards against monitors that report a zero refresh rate.