### PR TITLE
pipewire: Set SPA_DATA_FLAG_READABLE flag on pw buffers

### DIFF
--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -506,6 +506,7 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	struct xdpw_screencast_instance *cast = data;
 	struct spa_data *d;
 	enum spa_data_type t;
+	uint32_t flags = SPA_DATA_FLAG_READABLE;
 
 	logprint(DEBUG, "pipewire: add buffer event handle");
 
@@ -515,6 +516,9 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 	if ((d[0].type & (1u << SPA_DATA_MemFd)) > 0) {
 		assert(cast->buffer_type == WL_SHM);
 		t = SPA_DATA_MemFd;
+#ifdef SPA_DATA_FLAG_MAPPABLE
+		flags = flags | SPA_DATA_FLAG_MAPPABLE;
+#endif
 	} else if ((d[0].type & (1u << SPA_DATA_DmaBuf)) > 0) {
 		assert(cast->buffer_type == DMABUF);
 		t = SPA_DATA_DmaBuf;
@@ -543,7 +547,7 @@ static void pwr_handle_stream_add_buffer(void *data, struct pw_buffer *buffer) {
 		d[plane].chunk->size = xdpw_buffer->size[plane];
 		d[plane].chunk->stride = xdpw_buffer->stride[plane];
 		d[plane].chunk->offset = xdpw_buffer->offset[plane];
-		d[plane].flags = SPA_DATA_FLAG_READABLE;
+		d[plane].flags = flags;
 		d[plane].fd = xdpw_buffer->fd[plane];
 		d[plane].data = NULL;
 		// clients have implemented to check chunk->size if the buffer is valid instead


### PR DESCRIPTION
Hello,
I'm a developer of [UltraGrid](https://github.com/CESNET/UltraGrid) and I've noticed that after upgrading to PipeWire 1.6 our screen capture began crashing when used with xdg-desktop-portal-wlr.

I've done some investigation and the issue seems to be that after  PipeWire/pipewire@5ccaf297 buffers are no longer mmaped with PROT_READ unless the SPA_DATA_FLAG_READABLE is set.

Setting the flag fixes the issue for me and seems like an obvious solution, but I'm not absolutely sure if changing the flag could have some other subtle implications so feedback is welcome.

Also, the issue is not reproducible in obs, firefox or chromium as they all seem to negotiate dmaBuf and not MemFd as we do in UltraGrid.

Thanks