### PR TITLE
screencast/ext_image_copy: destroy stale frame before creating a new one

### DIFF
--- a/src/screencast/ext_image_copy.c
+++ b/src/screencast/ext_image_copy.c
@@ -276,6 +276,11 @@ static void ext_register_frame_cb(struct xdpw_screencast_instance *cast) {
 	if (!cast->ext_session.capture_session) {
 		ext_register_session_cb(cast);
 	}
+	if (cast->ext_session.frame) {
+		logprint(WARN, "ext: destroying stale frame before creating a new one");
+		ext_image_copy_capture_frame_v1_destroy(cast->ext_session.frame);
+		cast->ext_session.frame = NULL;
+	}
 	cast->ext_session.frame = ext_image_copy_capture_session_v1_create_frame(
 			cast->ext_session.capture_session);
 	ext_image_copy_capture_frame_v1_add_listener(cast->ext_session.frame,


### PR DESCRIPTION
## Summary

Fix a protocol violation that causes xdpw to crash with `duplicate_frame`
when using `ext-image-copy-capture-v1`.

## Problem

`ext_register_frame_cb()` unconditionally calls `create_frame` without checking whether a previous frame object still exists. The `ext-image-copy-capture-v1` protocol forbids more than one active frame per session, and wlroots raises a fatal `duplicate_frame` protocol error when this invariant is violated, killing the Wayland connection.

The crash manifests as screen sharing freezing in Discord/OBS, with the following in the logs:

```
ext_image_copy_capture_session_v1#15: error 1: session already has a frame object
wl_display_dispatch failed: Protocol error
```

systemd restarts xdpw, but the capture session is lost, so the consumer sees a frozen frame.

## Root cause

One scenario that triggers this is a PipeWire stream state transition from `STREAMING` to `PAUSED` and back to `STREAMING`.  `pwr_handle_stream_state_changed()` enqueues the PipeWire buffer (setting `pw_buffer` to NULL) but does not destroy the in-flight ext-image-copy-capture frame. When PipeWire later calls `on_process`, the guard on `pw_buffer` passes and `ext_register_frame_cb()` creates a new frame without destroying the previous one.

## Fix

Destroy any existing frame object in `ext_register_frame_cb()` before creating a new one. This is a defensive guard that covers all possible code paths leading to a stale frame, not just the `PAUSED` transition.

## Testing

- **Without fix**: injecting a duplicate `create_frame` call immediately crashes xdpw with the protocol error shown above.
- **With fix**: the guard fires (`ext: destroying stale frame before creating a new one`), the stale frame is destroyed, a new one is created, and xdpw continues operating normally. The guard was also observed firing during normal operation (not just injected), confirming the bug occurs in practice.

## Related

- #340 — Alternative fix proposal (return early instead of destroying)
- #339 — Fix for damage when frame is not set
