### PR TITLE
screencast: bump backend to v6 with mapping_id and pipewire-serial

### DIFF
--- a/include/screencast_common.h
+++ b/include/screencast_common.h
@@ -9,9 +9,13 @@
 
 #include "fps_limit.h"
 
-// this seems to be right based on
-// https://github.com/flatpak/xdg-desktop-portal/blob/309a1fc0cf2fb32cceb91dbc666d20cf0a3202c2/src/screen-cast.c#L955
-#define XDP_CAST_PROTO_VER 4
+// Backend implements ScreenCast v6:
+//   v4 restore tokens, v5 mapping_id, v6 pipewire-serial.
+// The xdg-desktop-portal frontend exposes MIN(backend_version, 6) to
+// apps (see flatpak/xdg-desktop-portal#1942), so apps see v6 only when
+// this backend is loaded and supplies pipewire-serial in the stream
+// dict.
+#define XDP_CAST_PROTO_VER 6
 #define XDP_CAST_DATA_VER 1
 
 enum cursor_modes {
@@ -196,6 +200,7 @@ struct xdpw_screencast_instance {
 	struct spa_video_info_raw pwr_format;
 	uint32_t seq;
 	uint32_t node_id;
+	uint64_t pipewire_serial;
 	bool pwr_stream_state;
 	uint32_t framerate;
 

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ add_project_arguments([
 inc = include_directories('include')
 
 rt = cc.find_library('rt')
-pipewire = dependency('libpipewire-0.3', version: '>= 0.3.62')
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.64')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.24')
 iniparser = dependency('inih')

--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -10,6 +10,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdlib.h>
 #include <libdrm/drm_fourcc.h>
 
 #include "screencast.h"
@@ -347,14 +350,34 @@ void pwr_update_stream_param(struct xdpw_screencast_instance *cast) {
 	wl_array_release(&params);
 }
 
+static uint64_t read_object_serial(struct pw_stream *stream) {
+	const struct pw_properties *props = pw_stream_get_properties(stream);
+	if (!props) {
+		return 0;
+	}
+	const char *serial_str = pw_properties_get(props, PW_KEY_OBJECT_SERIAL);
+	if (!serial_str) {
+		return 0;
+	}
+	char *end = NULL;
+	errno = 0;
+	uint64_t serial = strtoull(serial_str, &end, 10);
+	if (errno != 0 || end == serial_str || end[0] != '\0') {
+		return 0;
+	}
+	return serial;
+}
+
 static void pwr_handle_stream_state_changed(void *data,
 		enum pw_stream_state old, enum pw_stream_state state, const char *error) {
 	struct xdpw_screencast_instance *cast = data;
 	cast->node_id = pw_stream_get_node_id(cast->stream);
+	cast->pipewire_serial = read_object_serial(cast->stream);
 
 	logprint(INFO, "pipewire: stream state changed to \"%s\"",
 		pw_stream_state_as_string(state));
-	logprint(INFO, "pipewire: node id is %d", (int)cast->node_id);
+	logprint(INFO, "pipewire: node id is %d, object.serial is %" PRIu64,
+		(int)cast->node_id, cast->pipewire_serial);
 
 	switch (state) {
 	case PW_STREAM_STATE_STREAMING:

--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -663,6 +663,20 @@ static int method_screencast_start(sd_bus_message *msg, void *data,
 	if (ret < 0) {
 		return ret;
 	}
+	if (cast->target->output && cast->target->output->name) {
+		ret = sd_bus_message_append(reply, "{sv}",
+			"mapping_id", "s", cast->target->output->name);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	if (cast->pipewire_serial != 0) {
+		ret = sd_bus_message_append(reply, "{sv}",
+			"pipewire-serial", "t", cast->pipewire_serial);
+		if (ret < 0) {
+			return ret;
+		}
+	}
 	ret = sd_bus_message_close_container(reply);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
Closes #377.

Implements xdg-desktop-portal ScreenCast v5 (`mapping_id`) and v6 (`pipewire-serial`) stream properties for the wlr backend.

## Why

PipeWire node IDs (uint32) are reused after stream destruction. When monitor hotplug or similar events tear down and recreate streams, consumers holding the old node_id can silently bind to a different stream. PipeWire fixed this in 0.3.64 with `object.serial` (uint64, monotonically increasing, never reused); the matching portal API change merged as flatpak/xdg-desktop-portal#1942.

`mapping_id` (v5) is the matching feature for multi-monitor input targeting: a stable identifier for the source the stream came from. For output streams that's just the output name.

## What changed

Three things, ~45 lines:

1. `include/screencast_common.h`: `XDP_CAST_PROTO_VER` 4 → 6, plus a new `uint64_t pipewire_serial` field on `xdpw_screencast_instance`.
2. `src/screencast/pipewire_screencast.c`: a small static helper `read_object_serial()` that reads `PW_KEY_OBJECT_SERIAL` from the stream's properties and parses it as `uint64_t`. Called right next to `pw_stream_get_node_id()` in `pwr_handle_stream_state_changed`.
3. `src/screencast/screencast.c`: in `method_screencast_start`, append two new entries to the stream properties dict: `mapping_id` (string, from `cast->target->output->name`) and `pipewire-serial` (uint64, from the cached value).

`meson.build`: bump `libpipewire-0.3` from `>= 0.3.62` to `>= 0.3.64` to align with the project-wide `object.serial` migration cutoff.

## Version negotiation

The xdg-desktop-portal frontend (post flatpak/xdg-desktop-portal#1942) derives its advertised ScreenCast version as `MIN(backend_version, 6)`. So apps see v6 only when this backend is loaded and supplies `pipewire-serial` in the stream dict. No v6 advertisement on backends that haven't bumped.

`pipewire-serial` is only emitted in the dict when extraction actually succeeds (non-zero), so the frontend can rely on its presence whenever v6 is advertised.

## Backward compatibility

Existing consumers that read only `node_id` from the stream tuple are unaffected. The new dict keys are additive. KDE has converged on the same fix in parallel (`plasma-wayland-protocols!129` merged 2026-04-30; `xdg-desktop-portal-kde!539` open).

## Testing

Verified with `gcc -fsyntax-only -Werror -Wall -Wextra`; full meson build via CI.

## Provenance and tooling

This change originated from work on RemoteDesktop integration with the wlr stack, where the need for `mapping_id` and `pipewire-serial` to flow through the wlr portal backend surfaced in real use. I agree to the Developer Certificate of Origin (`Signed-off-by` trailer on the commit) and disclose use of Claude Code (Opus) per the Use of LLMs policy (`Assisted-by` trailer on the commit). All code, architecture, and prose are composed, audited, and signed off by me.

Refs: flatpak/xdg-desktop-portal#1942, flatpak/xdg-desktop-portal#979.
