### PR TITLE
Touch up man page

### DIFF
--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -64,7 +64,8 @@ These options need to be placed under the **[screencast]** section.
 
 	The supported types are:
 	- default: xdpw will try to use the first chooser found in the list of hardcoded choosers
-	  (slurp, wmenu, wofi, rofi, bemenu, mew, fuzzel) and will fallback to an arbitrary output if none of those were found.
+	  (slurp only for whole monitors, wmenu, wofi, rofi, bemenu, mew, fuzzel) and will fall back
+	  to an arbitrary output if none of those were found.
 	- none: xdpw will allow screencast either on the output given by **output_name**, or if empty
 	  an arbitrary output without further interaction.
 	- simple, dmenu: xdpw will launch the chooser given by **chooser_cmd**. For more details
@@ -89,7 +90,7 @@ The chooser can be any program or script with the following behaviour:
      - The prefix "Monitor: " followed by the name of a valid output as given by **wayland-info**(1).
      - The prefix "Window: " followed by the ext-foreign-toplevel-list-v1 identifier as given by **lswt**(1).
    - For dmenu choosers: one of the lines provided via stdin.
-   Everything else will be handled as defined by the user.
+   Everything else will be handled as declined by the user.
 - To signal that the user has declined screencast, the chooser should exit without
   anything on stdout.
 

--- a/xdg-desktop-portal-wlr.5.scd
+++ b/xdg-desktop-portal-wlr.5.scd
@@ -89,7 +89,7 @@ The chooser can be any program or script with the following behaviour:
      - The prefix "Monitor: " followed by the name of a valid output as given by **wayland-info**(1).
      - The prefix "Window: " followed by the ext-foreign-toplevel-list-v1 identifier as given by **lswt**(1).
    - For dmenu choosers: one of the lines provided via stdin.
-   Everything else will be handled as declined by the user.
+   Everything else will be handled as defined by the user.
 - To signal that the user has declined screencast, the chooser should exit without
   anything on stdout.
 


### PR DESCRIPTION
Fixing two minor issues I've noticed while updating the Arch wiki.

The `slurp` note is important IMO, since I was previously used to it for screencasting but since updating to Sway 1.12 I've been surprised to see `wmenu` being used.

On another note, the markup seems a little iffy (I've noticed, in particular, [broken list rendering](https://man.archlinux.org/man/xdg-desktop-portal-wlr.5#OUTPUT_CHOOSER) and a missing cross-page link to `pipewire`. I could fix this by porting the man page to Mandoc format, but I'd like to have a vibe check first on whether that'd be desired. Thanks in advance! :)