### PR TITLE
screencast: default SelectSources to monitors

### DIFF
--- a/src/screencast/screencast.c
+++ b/src/screencast/screencast.c
@@ -371,7 +371,7 @@ static int method_screencast_select_sources(sd_bus_message *msg, void *data,
 
 	char *key;
 	int innerRet = 0;
-	uint32_t type_mask = 0;
+	uint32_t type_mask = MONITOR;
 	struct xdpw_screencast_restore_data restore_data = {0};
 	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
 		innerRet = sd_bus_message_read(msg, "s", &key);


### PR DESCRIPTION
## Summary

- Default `SelectSources` to monitor capture when the optional `types` key is omitted.
- Keep explicit `types` handling unchanged.

## Rationale

The ScreenCast portal default for omitted `types` is monitor capture. Starting the mask at zero leaves the request with no supported targets and causes `No supported targets specified` before target selection.

Closes #379.

## Testing

- `git diff --check`
- Fedora 44 container: `meson setup /tmp/xdpw-build -Dman-pages=disabled -Dsystemd=disabled && ninja -C /tmp/xdpw-build`

## Provenance and tooling

This patch was prepared with AI assistance. Scarab Systems reviewed and approved the submitted change. The final patch is intentionally small, manually inspected, and tested by the submitter.
